### PR TITLE
[KHP-000] fix(web): avoid passing function to client component

### DIFF
--- a/apps/web/src/app/(mainapp)/loss/[id]/layout.tsx
+++ b/apps/web/src/app/(mainapp)/loss/[id]/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { AutoBreadcrumb } from "@/components/auto-breadcrumb";
+import LossBreadcrumb from "./loss-breadcrumb";
 
 export const metadata: Metadata = {
   title: "KHP | Loss Details",
@@ -19,12 +19,7 @@ export default async function LossLayout({ children }: LossLayoutProps) {
     <div className="flex flex-col h-full">
       <header className="border-b border-khp-secondary bg-background sticky top-0 z-10 mb-4">
         <div className="px-6 py-4 space-y-3">
-          <AutoBreadcrumb
-            listClassName="text-xl font-semibold"
-            lastLabel="Loss"
-            isLink={(href) => href !== "/loss"}
-            overrides={{ loss: "Losses" }}
-          />
+          <LossBreadcrumb />
         </div>
       </header>
       <div className="flex-1 overflow-auto p-4">{children}</div>

--- a/apps/web/src/app/(mainapp)/loss/[id]/loss-breadcrumb.tsx
+++ b/apps/web/src/app/(mainapp)/loss/[id]/loss-breadcrumb.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { AutoBreadcrumb } from '@/components/auto-breadcrumb';
+
+export default function LossBreadcrumb() {
+  return (
+    <AutoBreadcrumb
+      listClassName="text-xl font-semibold"
+      lastLabel="Loss"
+      isLink={(href) => href !== '/loss'}
+      overrides={{ loss: 'Losses' }}
+    />
+  );
+}
+


### PR DESCRIPTION
## Summary
- create a client-side `LossBreadcrumb` wrapper for AutoBreadcrumb
- use the wrapper in loss layout to avoid passing functions from server

## Testing
- `npm test` *(fails: command not found)*
- `npm run lint` *(fails: command not found)*
- `npm run check-types` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c756fd9a7c8327bd9ad2db86d24db2