### PR TITLE
[KHP-244] chore(web): Remove 'Move Quantity' from urlKeyOptions

### DIFF
--- a/apps/web/src/components/quickaccess/quick-access-button-form.tsx
+++ b/apps/web/src/components/quickaccess/quick-access-button-form.tsx
@@ -63,7 +63,6 @@ const urlKeyOptions = [
   { value: "menu_card", label: "Menu Card" },
   { value: "stock", label: "Stock" },
   { value: "take_order", label: "Take Order" },
-  { value: "move_quantity", label: "Move Quantity" },
 ];
 
 const colorOptions = [


### PR DESCRIPTION
The 'move_quantity' option has been removed from the urlKeyOptions array in the quick access button form component.