### PR TITLE
[KHP-269] fix(web): Update column header for a la carte meals

### DIFF
--- a/apps/web/src/components/meals/meals-column.tsx
+++ b/apps/web/src/components/meals/meals-column.tsx
@@ -99,7 +99,7 @@ export const columns: ColumnDef<Meals>[] = [
   }, */
   {
     accessorKey: "is_a_la_carte",
-    header: "Actually on the menu ?",
+    header: 'Actually "a la carte" ?',
     cell: ({ row }) =>
       row.original.is_a_la_carte ? (
         <p className="text-green-600 flex items-center gap-1">


### PR DESCRIPTION
Changed the column header from 'Actually on the menu ?' to 'Actually "a la carte" ?' for clarity in the meals table.