### PR TITLE
[KHP-247] feat(pwa): Add offline support with queue, cache, and status UI

### DIFF
--- a/apps/pwa/src/components/Layout.tsx
+++ b/apps/pwa/src/components/Layout.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft } from "lucide-react";
 import { useLocation, useMatch, useNavigate } from "@tanstack/react-router";
 import { useProduct } from "../stores/product-store";
 import { useHandleItemStore } from "../stores/handleitem-store";
+import { OfflineStatusBanner } from "./OfflineStatusBanner";
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -137,7 +138,10 @@ export function Layout({ children, className }: LayoutProps) {
           </div>
         </div>
       </header>
-      <main>{children}</main>
+      <main>
+        {!scanMatch && <OfflineStatusBanner />}
+        {children}
+      </main>
     </div>
   );
 }

--- a/apps/pwa/src/components/OfflineStatusBanner.tsx
+++ b/apps/pwa/src/components/OfflineStatusBanner.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import { WifiOff, RefreshCcw } from "lucide-react";
+import { Button } from "@workspace/ui/components/button";
+import { useOfflineStore } from "../stores/offline-store";
+import api from "../lib/api";
+
+function formatTimestamp(timestamp: number | null): string | null {
+  if (!timestamp) return null;
+  const date = new Date(timestamp);
+  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+export function OfflineStatusBanner() {
+  const { isOnline, queuedCount, lastSyncedAt } = useOfflineStore();
+  const [isSyncing, setIsSyncing] = useState(false);
+
+  if (isOnline && queuedCount === 0) {
+    return null;
+  }
+
+  const pendingLabel = `${queuedCount} action${queuedCount > 1 ? "s" : ""} en attente`;
+  const lastSyncLabel = formatTimestamp(lastSyncedAt);
+
+  const statusMessage = isOnline
+    ? queuedCount > 0
+      ? `Synchronisation en cours… ${pendingLabel}.`
+      : "Synchronisation terminée."
+    : queuedCount > 0
+      ? `Mode hors connexion. ${pendingLabel}.`
+      : "Vous êtes hors connexion. Les actions seront synchronisées dès le retour du réseau.";
+
+  const handleManualSync = async () => {
+    try {
+      setIsSyncing(true);
+      await api.flushOfflineQueue();
+    } catch (error) {
+      console.error("Manual sync failed", error);
+    } finally {
+      setIsSyncing(false);
+    }
+  };
+
+  return (
+    <div className="bg-amber-500 text-amber-950 px-4 py-3 flex items-center justify-between gap-3">
+      <div className="flex items-center gap-3">
+        <WifiOff className="h-5 w-5" aria-hidden="true" />
+        <div className="flex flex-col text-sm">
+          <span>{statusMessage}</span>
+          {lastSyncLabel && isOnline && queuedCount === 0 && (
+            <span className="text-xs opacity-80">
+              Dernière synchronisation à {lastSyncLabel}.
+            </span>
+          )}
+        </div>
+      </div>
+      {queuedCount > 0 && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-amber-950 hover:bg-amber-600"
+          onClick={handleManualSync}
+          disabled={isSyncing || !isOnline}
+        >
+          <RefreshCcw className={`h-4 w-4 mr-2 ${isSyncing ? "animate-spin" : ""}`} />
+          {isSyncing ? "Synchronisation" : "Relancer"}
+        </Button>
+      )}
+    </div>
+  );
+}
+

--- a/apps/pwa/src/lib/__tests__/handleScanType.test.ts
+++ b/apps/pwa/src/lib/__tests__/handleScanType.test.ts
@@ -7,6 +7,7 @@ vi.mock('@workspace/graphql', () => ({
 
 import handleScanType from '../handleScanType'
 import { graphqlRequest } from '../graph-client'
+import { graphqlRequestWithOffline } from '../offline-graphql'
 import {
   GetIngredientDocument,
   OpenFoodFactsProxyDocument,
@@ -18,36 +19,53 @@ vi.mock('../graph-client', () => ({
   graphqlRequest: vi.fn(),
 }))
 
+vi.mock('../offline-graphql', () => ({
+  graphqlRequestWithOffline: vi.fn(),
+}))
+
 const mockGraphqlRequest = vi.mocked(graphqlRequest)
+const mockGraphqlRequestWithOffline = vi.mocked(graphqlRequestWithOffline)
 
 describe('handleScanType', () => {
   beforeEach(() => {
     mockGraphqlRequest.mockReset()
+    mockGraphqlRequestWithOffline.mockReset()
   })
 
   it('returns ingredient data when barcode exists in database', async () => {
-    mockGraphqlRequest.mockResolvedValueOnce({
-      ingredient: {
-        id: 'ING-1',
-        image_url: 'https://img',
-        name: 'Farine',
-        category: { id: 'cat', name: 'Ingredients secs', __typename: 'Category' },
-        unit: 'kg',
-        base_quantity: 5,
-        base_unit: 'kg',
-        quantities: [{ id: 'q1' }],
-        __typename: 'Ingredient',
+    mockGraphqlRequestWithOffline.mockResolvedValueOnce({
+      data: {
+        ingredient: {
+          id: 'ING-1',
+          image_url: 'https://img',
+          name: 'Farine',
+          category: { id: 'cat', name: 'Ingredients secs', __typename: 'Category' },
+          unit: 'kg',
+          base_quantity: 5,
+          base_unit: 'kg',
+          quantities: [{ id: 'q1' }],
+          __typename: 'Ingredient',
+        },
       },
-    } as unknown as GetIngredientQuery)
+      source: 'network',
+      timestamp: 123456,
+    } as unknown as {
+      data: GetIngredientQuery;
+      source: 'network';
+      timestamp: number;
+    })
 
     const result = await handleScanType('barcode', '1234567890')
 
-    expect(mockGraphqlRequest).toHaveBeenCalledTimes(1)
-    expect(mockGraphqlRequest).toHaveBeenCalledWith(GetIngredientDocument, {
-      barcode: '1234567890',
-      includeStockMovements: false,
-    })
-    expect(result).toMatchObject({
+    expect(mockGraphqlRequestWithOffline).toHaveBeenCalledTimes(1)
+    expect(mockGraphqlRequestWithOffline).toHaveBeenCalledWith(
+      GetIngredientDocument,
+      {
+        barcode: '1234567890',
+        includeStockMovements: false,
+      }
+    )
+    expect(result.data).toMatchObject({
       product_image: 'https://img',
       product_name: 'Farine',
       product_category: { id: 'cat', name: 'Ingredients secs' },
@@ -58,33 +76,45 @@ describe('handleScanType', () => {
       product_internal_id: 'ING-1',
       quantities: [{ id: 'q1' }],
     })
+    expect(result.source).toBe('network')
   })
 
   it('falls back to OpenFoodFacts when barcode is unknown', async () => {
-    mockGraphqlRequest
-      .mockResolvedValueOnce({ ingredient: null } as unknown as GetIngredientQuery)
-      .mockResolvedValueOnce({
-        search: {
-          imageUrl: 'http://cdn/image.png',
-          product_name: 'Chocolat',
-          base_quantity: 2,
-          is_already_in_database: false,
-          ingredient_id: null,
-          unit: 'kg',
-        },
-      } as unknown as OpenFoodFactsProxyQuery)
+    mockGraphqlRequestWithOffline.mockResolvedValueOnce({
+      data: { ingredient: null },
+      source: 'network',
+      timestamp: 0,
+    } as unknown as {
+      data: GetIngredientQuery;
+      source: 'network';
+      timestamp: number;
+    })
+
+    mockGraphqlRequest.mockResolvedValueOnce({
+      search: {
+        imageUrl: 'http://cdn/image.png',
+        product_name: 'Chocolat',
+        base_quantity: 2,
+        is_already_in_database: false,
+        ingredient_id: null,
+        unit: 'kg',
+      },
+    } as unknown as OpenFoodFactsProxyQuery)
 
     const result = await handleScanType('barcode', '0987654321')
 
-    expect(mockGraphqlRequest).toHaveBeenNthCalledWith(1, GetIngredientDocument, {
-      barcode: '0987654321',
-      includeStockMovements: false,
-    })
-    expect(mockGraphqlRequest).toHaveBeenNthCalledWith(2, OpenFoodFactsProxyDocument, {
+    expect(mockGraphqlRequestWithOffline).toHaveBeenCalledWith(
+      GetIngredientDocument,
+      {
+        barcode: '0987654321',
+        includeStockMovements: false,
+      }
+    )
+    expect(mockGraphqlRequest).toHaveBeenCalledWith(OpenFoodFactsProxyDocument, {
       barcode: '0987654321',
       page: 1,
     })
-    expect(result).toMatchObject({
+    expect(result.data).toMatchObject({
       product_image: 'http://cdn/image.png',
       product_name: 'Chocolat',
       product_category: { id: '', name: '' },
@@ -94,26 +124,37 @@ describe('handleScanType', () => {
       product_already_in_database: false,
       product_internal_id: undefined,
     })
+    expect(result.source).toBe('derived')
   })
 
   it('throws when product cannot be located for internal id', async () => {
-    mockGraphqlRequest.mockResolvedValueOnce({
-      ingredient: null,
-    } as unknown as GetIngredientQuery)
+    mockGraphqlRequestWithOffline.mockResolvedValueOnce({
+      data: { ingredient: null },
+      source: 'network',
+      timestamp: 0,
+    } as unknown as {
+      data: GetIngredientQuery;
+      source: 'network';
+      timestamp: number;
+    })
 
     await expect(handleScanType('internalId', 'ING-404')).rejects.toThrow(
       'Product not found'
     )
-    expect(mockGraphqlRequest).toHaveBeenCalledWith(GetIngredientDocument, {
-      id: 'ING-404',
-      includeStockMovements: false,
-    })
+    expect(mockGraphqlRequestWithOffline).toHaveBeenCalledWith(
+      GetIngredientDocument,
+      {
+        id: 'ING-404',
+        includeStockMovements: false,
+      }
+    )
   })
 
   it('returns default shape in manual mode without calling API', async () => {
     const result = await handleScanType('manual', undefined)
     expect(mockGraphqlRequest).not.toHaveBeenCalled()
-    expect(result).toMatchObject({
+    expect(mockGraphqlRequestWithOffline).not.toHaveBeenCalled()
+    expect(result.data).toMatchObject({
       product_image: '',
       product_name: '',
       product_category: { id: '', name: '' },
@@ -122,5 +163,6 @@ describe('handleScanType', () => {
       product_already_in_database: false,
       product_internal_id: undefined,
     })
+    expect(result.source).toBe('derived')
   })
 })

--- a/apps/pwa/src/lib/__tests__/http-client.offline.test.ts
+++ b/apps/pwa/src/lib/__tests__/http-client.offline.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const queueRequestMock = vi.fn();
+const readQueuedRequestsMock = vi.fn();
+const dropQueuedRequestMock = vi.fn();
+const markRequestAsFailedMock = vi.fn();
+const serializeRequestBodyMock = vi.fn();
+const deserializeRequestBodyMock = vi.fn();
+
+vi.mock("../offline-queue", () => ({
+  queueRequest: queueRequestMock,
+  readQueuedRequests: readQueuedRequestsMock,
+  dropQueuedRequest: dropQueuedRequestMock,
+  markRequestAsFailed: markRequestAsFailedMock,
+  serializeRequestBody: serializeRequestBodyMock,
+  deserializeRequestBody: deserializeRequestBodyMock,
+}));
+
+vi.mock("../offline-db", async () => {
+  const actual = await vi.importActual<typeof import("../offline-db")>(
+    "../offline-db"
+  );
+  return actual;
+});
+
+describe("ImprovedHttpClient offline behaviour", () => {
+  let ImprovedHttpClient: typeof import("../http-client").ImprovedHttpClient;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  const setNavigatorOnline = (value: boolean) => {
+    Object.defineProperty(window.navigator, "onLine", {
+      configurable: true,
+      get: () => value,
+    });
+  };
+
+  beforeEach(async () => {
+    vi.resetModules();
+
+    queueRequestMock.mockResolvedValue({ queued: true, id: "q1", queuedAt: 0 });
+    readQueuedRequestsMock.mockResolvedValue([]);
+    dropQueuedRequestMock.mockResolvedValue(undefined);
+    markRequestAsFailedMock.mockResolvedValue(undefined);
+    serializeRequestBodyMock.mockImplementation((body?: BodyInit | null) => ({
+      kind: "string",
+      value: typeof body === "string" ? body : JSON.stringify(body ?? {}),
+    }));
+    deserializeRequestBodyMock.mockImplementation(() => "queued-body");
+
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    setNavigatorOnline(false);
+    document.cookie = "XSRF-TOKEN=offline-token; path=/";
+
+    ({ ImprovedHttpClient } = await import("../http-client"));
+
+    vi.spyOn(window, "dispatchEvent");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    document.cookie = "XSRF-TOKEN=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/";
+    queueRequestMock.mockReset();
+    readQueuedRequestsMock.mockReset();
+    dropQueuedRequestMock.mockReset();
+    markRequestAsFailedMock.mockReset();
+    serializeRequestBodyMock.mockReset();
+    deserializeRequestBodyMock.mockReset();
+  });
+
+  it("queues mutations when the network is unavailable", async () => {
+    fetchMock.mockRejectedValue(new TypeError("Failed to fetch"));
+
+    const client = new ImprovedHttpClient({ baseUrl: "https://api.test" });
+
+    const result = await client.post("/api/ingredients", { foo: "bar" });
+
+    expect(result).toEqual({ queued: true });
+    expect(queueRequestMock).toHaveBeenCalledTimes(1);
+    expect(queueRequestMock).toHaveBeenCalledWith({
+      baseUrl: "https://api.test",
+      path: "/api/ingredients",
+      method: "POST",
+      headers: expect.objectContaining({
+        "Content-Type": "application/json",
+      }),
+      body: "queued-body",
+      requiresCsrf: true,
+    });
+    expect(window.dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "khp:offline-queue" })
+    );
+  });
+
+  it("replays queued requests when connectivity returns", async () => {
+    setNavigatorOnline(true);
+
+    const queuedRecord = {
+      id: "queued-1",
+      path: "/api/tasks",
+      method: "POST",
+      baseUrl: "https://api.test",
+      headers: { "Content-Type": "application/json" },
+      body: { kind: "string", value: "{\"foo\":\"bar\"}" },
+      queuedAt: Date.now(),
+      attempts: 0,
+      requiresCsrf: true,
+    } as const;
+
+    readQueuedRequestsMock
+      .mockResolvedValueOnce([queuedRecord])
+      .mockResolvedValueOnce([]);
+    deserializeRequestBodyMock.mockReturnValueOnce('{"foo":"bar"}');
+
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: { get: () => null, entries: () => [] },
+    } as unknown as Response);
+
+    const client = new ImprovedHttpClient({ baseUrl: "https://api.test" });
+
+    await client.flushOfflineQueue();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fetchMock).toHaveBeenCalledWith("https://api.test/api/tasks", {
+      method: "POST",
+      headers: expect.objectContaining({ "Content-Type": "application/json" }),
+      body: '{"foo":"bar"}',
+      credentials: "include",
+    });
+    expect(dropQueuedRequestMock).toHaveBeenCalledWith("queued-1");
+    expect(markRequestAsFailedMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/pwa/src/lib/__tests__/offline-graphql.test.ts
+++ b/apps/pwa/src/lib/__tests__/offline-graphql.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const graphqlRequestMock = vi.fn();
+const cacheGraphQLResponseMock = vi.fn();
+const getCachedGraphQLResponseMock = vi.fn();
+
+vi.mock("../graph-client", () => ({
+  graphqlRequest: graphqlRequestMock,
+}));
+
+vi.mock("../offline-cache", () => ({
+  cacheGraphQLResponse: cacheGraphQLResponseMock,
+  getCachedGraphQLResponse: getCachedGraphQLResponseMock,
+}));
+
+describe("graphqlRequestWithOffline", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    graphqlRequestMock.mockReset();
+    cacheGraphQLResponseMock.mockReset();
+    getCachedGraphQLResponseMock.mockReset();
+  });
+
+  it("caches successful network responses", async () => {
+    const payload = { foo: "bar" };
+    graphqlRequestMock.mockResolvedValue(payload);
+    cacheGraphQLResponseMock.mockResolvedValue({
+      value: payload,
+      timestamp: 111,
+    });
+
+    const { graphqlRequestWithOffline } = await import("../offline-graphql");
+
+    const result = await graphqlRequestWithOffline("DocumentNode", { id: 1 });
+
+    expect(result).toMatchObject({
+      data: payload,
+      source: "network",
+    });
+    expect(graphqlRequestMock).toHaveBeenCalledWith("DocumentNode", { id: 1 }, undefined);
+    expect(cacheGraphQLResponseMock).toHaveBeenCalledWith(
+      "DocumentNode",
+      { id: 1 },
+      payload
+    );
+  });
+
+  it("returns cached data when the network request fails", async () => {
+    const cached = { value: { foo: "cached" }, timestamp: 222 };
+    graphqlRequestMock.mockRejectedValue(new Error("Network down"));
+    getCachedGraphQLResponseMock.mockResolvedValue(cached);
+
+    const { graphqlRequestWithOffline } = await import("../offline-graphql");
+
+    const result = await graphqlRequestWithOffline("DocumentNode", { id: 42 });
+
+    expect(result).toMatchObject({
+      data: cached.value,
+      source: "cache",
+      timestamp: 222,
+      error: expect.any(Error),
+    });
+    expect(cacheGraphQLResponseMock).not.toHaveBeenCalled();
+  });
+});
+

--- a/apps/pwa/src/lib/__tests__/offline-status.test.ts
+++ b/apps/pwa/src/lib/__tests__/offline-status.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const readQueuedRequestsMock = vi.fn();
+
+const setNavigatorOnline = (value: boolean) => {
+  Object.defineProperty(window.navigator, "onLine", {
+    configurable: true,
+    get: () => value,
+  });
+};
+
+describe("initializeOfflineStatusListeners", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    readQueuedRequestsMock.mockReset();
+    vi.doMock("../offline-queue", () => ({
+      readQueuedRequests: readQueuedRequestsMock,
+    }));
+    setNavigatorOnline(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("hydrates the offline store and reacts to queue events", async () => {
+    readQueuedRequestsMock.mockResolvedValue([
+      {
+        id: "queued-1",
+        baseUrl: "https://api.test",
+        method: "POST",
+        path: "/api/demo",
+        queuedAt: Date.now(),
+        attempts: 0,
+      },
+    ]);
+
+    const { initializeOfflineStatusListeners } = await import("../offline-status");
+    const { useOfflineStore } = await import("../../stores/offline-store");
+
+    useOfflineStore.setState({ isOnline: true, queuedCount: 0, lastSyncedAt: null });
+
+    initializeOfflineStatusListeners("https://api.test");
+    await Promise.resolve();
+
+    expect(useOfflineStore.getState().queuedCount).toBe(1);
+
+    window.dispatchEvent(
+      new CustomEvent("khp:offline-queue", {
+        detail: { count: 0, timestamp: 1234567890 },
+      })
+    );
+
+    expect(useOfflineStore.getState()).toMatchObject({
+      queuedCount: 0,
+      lastSyncedAt: 1234567890,
+    });
+
+    setNavigatorOnline(false);
+    window.dispatchEvent(new Event("offline"));
+
+    expect(useOfflineStore.getState().isOnline).toBe(false);
+  });
+});
+

--- a/apps/pwa/src/lib/handleScanType.ts
+++ b/apps/pwa/src/lib/handleScanType.ts
@@ -6,6 +6,12 @@ import {
 } from "@workspace/graphql";
 import { HandleItemSearch } from "../routes/_protected/handle-item";
 import { graphqlRequest } from "./graph-client";
+import { graphqlRequestWithOffline } from "./offline-graphql";
+import {
+  saveIngredientSnapshot,
+  getIngredientSnapshotById,
+  getIngredientSnapshotByBarcode,
+} from "./ingredient-cache";
 
 export type WantedDataType = {
   product_image: string;
@@ -19,115 +25,171 @@ export type WantedDataType = {
   quantities?: NonNullable<GetIngredientQuery["ingredient"]>["quantities"];
 };
 
+export interface HandleScanResult {
+  data: WantedDataType;
+  source: "network" | "cache" | "derived";
+  timestamp: number;
+}
+
+const EMPTY_RESULT: WantedDataType = {
+  product_image: "",
+  product_name: "",
+  product_category: {
+    id: "",
+    name: "",
+  },
+  product_units: "",
+  product_base_unit: "",
+};
+
+export function mapIngredientToWantedData(
+  ingredient: NonNullable<GetIngredientQuery["ingredient"]>
+): WantedDataType {
+  return {
+    product_image: ingredient.image_url ?? "",
+    product_name: ingredient.name ?? "",
+    product_category: ingredient.category,
+    product_units: ingredient.unit ?? "",
+    product_already_in_database: true,
+    product_internal_id: ingredient.id ?? undefined,
+    product_base_quantity:
+      ingredient.base_quantity != null
+        ? ingredient.base_quantity.toString()
+        : undefined,
+    quantities: ingredient.quantities,
+    product_base_unit: ingredient.base_unit ?? "",
+  };
+}
+
 const handleScanType = async (
   mode: HandleItemSearch["mode"],
   productId: string | undefined
-) => {
-  let wantedData: WantedDataType = {
-    product_image: "",
-    product_name: "",
-    product_category: {
-      id: "",
-      name: "",
-    },
-    product_units: "",
-    product_base_unit: "",
-  };
+): Promise<HandleScanResult> => {
+  if (mode === "barcode" && !productId) {
+    throw new Error("Barcode is required for barcode scan mode");
+  }
+
+  if (mode === "internalId" && !productId) {
+    throw new Error("Internal ID is required for internalId scan mode");
+  }
 
   if (mode === "barcode") {
-    const resultByBarcode = await graphqlRequest<GetIngredientQuery>(
-      GetIngredientDocument,
-      { barcode: productId!, includeStockMovements: false }
-    );
-    if (resultByBarcode.ingredient) {
-      wantedData = {
-        product_image: resultByBarcode.ingredient.image_url ?? "",
-        product_name: resultByBarcode.ingredient.name ?? "",
-        product_category: resultByBarcode.ingredient.category,
-        product_units: resultByBarcode.ingredient.unit ?? "",
-        product_already_in_database: true,
-        product_internal_id: resultByBarcode.ingredient.id ?? undefined,
-        product_base_quantity:
-          resultByBarcode.ingredient.base_quantity.toString(),
-        quantities: resultByBarcode.ingredient.quantities,
-        product_base_unit: resultByBarcode.ingredient.base_unit ?? "",
-      };
-      return wantedData;
+    try {
+      const ingredientResult = await graphqlRequestWithOffline<GetIngredientQuery>(
+        GetIngredientDocument,
+        { barcode: productId!, includeStockMovements: false }
+      );
+
+      if (ingredientResult.data.ingredient) {
+        const ingredient = ingredientResult.data.ingredient;
+        const normalized = mapIngredientToWantedData(ingredient);
+        await saveIngredientSnapshot(normalized, { barcode: productId! });
+
+        return {
+          data: normalized,
+          source: ingredientResult.source,
+          timestamp: ingredientResult.timestamp,
+        } satisfies HandleScanResult;
+      }
+    } catch (error) {
+      const isOffline = typeof navigator !== "undefined" && !navigator.onLine;
+      if (isOffline) {
+        const snapshot = await getIngredientSnapshotByBarcode(productId!);
+        if (snapshot?.value) {
+          return {
+            data: snapshot.value,
+            source: "cache",
+            timestamp: snapshot.timestamp,
+          } satisfies HandleScanResult;
+        }
+      }
+      throw error;
     }
 
-    const result = await graphqlRequest<OpenFoodFactsProxyQuery>(
+    const openFoodResult = await graphqlRequest<OpenFoodFactsProxyQuery>(
       OpenFoodFactsProxyDocument,
       {
         barcode: productId,
         page: 1,
       }
     );
-    if (!result.search) {
+
+    if (!openFoodResult.search) {
       throw new Error("Product not found");
     }
 
     const product_base_quantity =
-      result.search.base_quantity != null
-        ? String(result.search.base_quantity)
+      openFoodResult.search.base_quantity != null
+        ? String(openFoodResult.search.base_quantity)
         : undefined;
 
-    wantedData = {
-      product_image: result.search.imageUrl ?? "",
-      product_name: result.search.product_name ?? "",
-      product_category: {
-        id: "",
-        name: "",
-      },
-      product_units: "",
+    const derivedData: WantedDataType = {
+      ...EMPTY_RESULT,
+      product_image: openFoodResult.search.imageUrl ?? "",
+      product_name: openFoodResult.search.product_name ?? "",
       product_base_quantity,
       product_already_in_database:
-        result.search.is_already_in_database ?? false,
-      product_internal_id: result.search.ingredient_id ?? undefined,
-      product_base_unit: result.search.unit ?? "",
+        openFoodResult.search.is_already_in_database ?? false,
+      product_internal_id: openFoodResult.search.ingredient_id ?? undefined,
+      product_base_unit: openFoodResult.search.unit ?? "",
     };
-  } else if (mode === "internalId") {
-    const result = await graphqlRequest<GetIngredientQuery>(
-      GetIngredientDocument,
-      { id: productId, includeStockMovements: false }
-    );
 
-    if (!result.ingredient) {
-      throw new Error("Product not found");
-    }
+    await saveIngredientSnapshot(derivedData, { barcode: productId! });
 
-    wantedData = {
-      product_image: result.ingredient.image_url ?? "",
-      product_name: result.ingredient.name ?? "",
-      product_category: result.ingredient.category,
-      product_units: result.ingredient.unit ?? "",
-      product_already_in_database: true,
-      product_internal_id: result.ingredient.id ?? undefined,
-      product_base_quantity: result.ingredient.base_quantity.toString(),
-      quantities: result.ingredient.quantities,
-      product_base_unit: result.ingredient.base_unit ?? "",
-    };
-  } else if (mode === "manual") {
-    wantedData = {
-      product_image: "",
-      product_name: "",
-      product_category: {
-        id: "",
-        name: "",
-      },
-      product_units: "",
-      product_already_in_database: false,
-      product_internal_id: undefined,
-      product_base_unit: "",
-    };
+    return {
+      data: derivedData,
+      source: "derived",
+      timestamp: Date.now(),
+    } satisfies HandleScanResult;
   }
 
-  /* wantedData.product_category = Array.from(
-    new Set(
-      wantedData.product_category.map((cat) => cat.trim()).filter(Boolean)
-    )
-  ); */
+  if (mode === "internalId") {
+    const ingredientId = productId!;
+    try {
+      const ingredientResult = await graphqlRequestWithOffline<GetIngredientQuery>(
+        GetIngredientDocument,
+        { id: ingredientId, includeStockMovements: false }
+      );
 
-  return wantedData;
+      if (!ingredientResult.data.ingredient) {
+        throw new Error("Product not found");
+      }
+
+      const ingredient = ingredientResult.data.ingredient;
+      const normalized = mapIngredientToWantedData(ingredient);
+      await saveIngredientSnapshot(normalized);
+
+      return {
+        data: normalized,
+        source: ingredientResult.source,
+        timestamp: ingredientResult.timestamp,
+      } satisfies HandleScanResult;
+    } catch (error) {
+      const isOffline = typeof navigator !== "undefined" && !navigator.onLine;
+      if (isOffline) {
+        const snapshot = await getIngredientSnapshotById(ingredientId);
+        if (snapshot?.value) {
+          return {
+            data: snapshot.value,
+            source: "cache",
+            timestamp: snapshot.timestamp,
+          } satisfies HandleScanResult;
+        }
+      }
+
+      throw error;
+    }
+  }
+
+  return {
+    data: {
+      ...EMPTY_RESULT,
+      product_already_in_database: false,
+      product_internal_id: undefined,
+    },
+    source: "derived",
+    timestamp: Date.now(),
+  } satisfies HandleScanResult;
 };
 
 export default handleScanType;

--- a/apps/pwa/src/lib/ingredient-cache.ts
+++ b/apps/pwa/src/lib/ingredient-cache.ts
@@ -1,0 +1,45 @@
+import { saveDataCache, getDataCache } from "./offline-db";
+import type { OfflineCacheRecord } from "./offline-db";
+import type { WantedDataType } from "./handleScanType";
+
+const BY_ID_PREFIX = "ingredient:id:";
+const BY_BARCODE_PREFIX = "ingredient:barcode:";
+const SNAPSHOT_TTL = 1000 * 60 * 60 * 24 * 7; // 7 days
+
+async function saveSnapshot(key: string, data: WantedDataType) {
+  await saveDataCache(key, data, SNAPSHOT_TTL);
+}
+
+export async function saveIngredientSnapshot(
+  data: WantedDataType,
+  options?: { barcode?: string }
+): Promise<void> {
+  const tasks: Array<Promise<void>> = [];
+
+  if (data.product_internal_id) {
+    tasks.push(
+      saveSnapshot(`${BY_ID_PREFIX}${data.product_internal_id}`, data)
+    );
+  }
+
+  if (options?.barcode) {
+    tasks.push(saveSnapshot(`${BY_BARCODE_PREFIX}${options.barcode}`, data));
+  }
+
+  if (tasks.length === 0) return;
+  await Promise.allSettled(tasks);
+}
+
+async function readSnapshot(
+  key: string
+): Promise<OfflineCacheRecord<WantedDataType> | null> {
+  return (await getDataCache<WantedDataType>(key)) ?? null;
+}
+
+export function getIngredientSnapshotById(id: string) {
+  return readSnapshot(`${BY_ID_PREFIX}${id}`);
+}
+
+export function getIngredientSnapshotByBarcode(barcode: string) {
+  return readSnapshot(`${BY_BARCODE_PREFIX}${barcode}`);
+}

--- a/apps/pwa/src/lib/offline-cache.ts
+++ b/apps/pwa/src/lib/offline-cache.ts
@@ -1,0 +1,63 @@
+import type { RequestDocument, Variables } from "graphql-request";
+import {
+  type OfflineCacheRecord,
+  deleteDataCache,
+  getDataCache,
+  saveDataCache,
+} from "./offline-db";
+import { hashString } from "../utils/hash";
+
+const DEFAULT_TTL = 1000 * 60 * 60 * 24; // 24 hours
+
+function serializeDocument(document: RequestDocument): string {
+  if (typeof document === "string") {
+    return document;
+  }
+
+  try {
+    return JSON.stringify(document);
+  } catch (error) {
+    console.warn("Failed to stringify GraphQL document for caching", error);
+    return String(document);
+  }
+}
+
+function buildGraphQLCacheKey(
+  document: RequestDocument,
+  variables?: Variables
+): string {
+  const payload = {
+    document: serializeDocument(document),
+    variables: variables ?? null,
+  };
+
+  const rawKey = JSON.stringify(payload);
+  return `gql:${hashString(rawKey)}`;
+}
+
+export async function cacheGraphQLResponse<T>(
+  document: RequestDocument,
+  variables: Variables | undefined,
+  value: T,
+  ttl = DEFAULT_TTL
+): Promise<OfflineCacheRecord<T>> {
+  const cacheKey = buildGraphQLCacheKey(document, variables);
+  return saveDataCache(cacheKey, value, ttl);
+}
+
+export async function getCachedGraphQLResponse<T>(
+  document: RequestDocument,
+  variables?: Variables
+): Promise<OfflineCacheRecord<T> | null> {
+  const cacheKey = buildGraphQLCacheKey(document, variables);
+  return getDataCache<T>(cacheKey);
+}
+
+export async function invalidateGraphQLCache(
+  document: RequestDocument,
+  variables?: Variables
+): Promise<void> {
+  const cacheKey = buildGraphQLCacheKey(document, variables);
+  await deleteDataCache(cacheKey);
+}
+

--- a/apps/pwa/src/lib/offline-db.ts
+++ b/apps/pwa/src/lib/offline-db.ts
@@ -1,0 +1,256 @@
+const DB_NAME = "khp-offline";
+const DB_VERSION = 1;
+const DATA_STORE = "data-cache";
+const QUEUE_STORE = "request-queue";
+
+export interface OfflineCacheRecord<T> {
+  value: T;
+  timestamp: number;
+  ttl?: number;
+}
+
+export interface OfflineRequestRecord {
+  id: string;
+  method: string;
+  path: string;
+  baseUrl: string;
+  body?: unknown;
+  headers?: Record<string, string>;
+  queuedAt: number;
+  attempts: number;
+  lastError?: string;
+  requiresCsrf?: boolean;
+}
+
+let dbPromise: Promise<IDBDatabase | null> | null = null;
+
+const memoryDataStore = new Map<string, OfflineCacheRecord<unknown>>();
+const memoryQueueStore = new Map<string, OfflineRequestRecord>();
+
+function isIndexedDBSupported(): boolean {
+  return typeof indexedDB !== "undefined";
+}
+
+async function openDatabase(): Promise<IDBDatabase | null> {
+  if (!isIndexedDBSupported()) {
+    return null;
+  }
+
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(DATA_STORE)) {
+        db.createObjectStore(DATA_STORE);
+      }
+      if (!db.objectStoreNames.contains(QUEUE_STORE)) {
+        db.createObjectStore(QUEUE_STORE);
+      }
+    };
+
+    request.onsuccess = () => {
+      resolve(request.result);
+    };
+
+    request.onerror = () => {
+      reject(request.error);
+    };
+  });
+}
+
+async function getDatabase(): Promise<IDBDatabase | null> {
+  if (!dbPromise) {
+    dbPromise = openDatabase().catch((error) => {
+      console.error("Failed to open offline database", error);
+      return null;
+    });
+  }
+
+  return dbPromise;
+}
+
+async function runTransaction(
+  db: IDBDatabase,
+  storeName: string,
+  mode: IDBTransactionMode,
+  operation: (store: IDBObjectStore) => void
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(storeName, mode);
+    const store = tx.objectStore(storeName);
+
+    try {
+      operation(store);
+    } catch (error) {
+      reject(error);
+      return;
+    }
+
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error);
+  });
+}
+
+export async function saveDataCache<T>(
+  key: string,
+  value: T,
+  ttl?: number
+): Promise<OfflineCacheRecord<T>> {
+  const record: OfflineCacheRecord<T> = {
+    value,
+    timestamp: Date.now(),
+    ttl,
+  };
+
+  const db = await getDatabase();
+
+  if (!db) {
+    memoryDataStore.set(key, record);
+    return record;
+  }
+
+  await runTransaction(db, DATA_STORE, "readwrite", (store) => {
+    store.put(record, key);
+  });
+
+  return record;
+}
+
+export async function deleteDataCache(key: string): Promise<void> {
+  const db = await getDatabase();
+
+  if (!db) {
+    memoryDataStore.delete(key);
+    return;
+  }
+
+  await runTransaction(db, DATA_STORE, "readwrite", (store) => {
+    store.delete(key);
+  });
+}
+
+export async function getDataCache<T>(
+  key: string
+): Promise<OfflineCacheRecord<T> | null> {
+  const db = await getDatabase();
+
+  if (!db) {
+    const record = memoryDataStore.get(key) as
+      | OfflineCacheRecord<T>
+      | undefined;
+    if (!record) {
+      return null;
+    }
+
+    if (record.ttl && Date.now() - record.timestamp > record.ttl) {
+      memoryDataStore.delete(key);
+      return null;
+    }
+
+    return record;
+  }
+
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(DATA_STORE, "readonly");
+    const store = tx.objectStore(DATA_STORE);
+    const request = store.get(key);
+
+    request.onsuccess = async () => {
+      const record = request.result as OfflineCacheRecord<T> | undefined;
+      if (!record) {
+        resolve(null);
+        return;
+      }
+
+      if (record.ttl && Date.now() - record.timestamp > record.ttl) {
+        try {
+          await deleteDataCache(key);
+        } catch (error) {
+          console.warn("Failed to purge expired cache entry", error);
+        }
+        resolve(null);
+        return;
+      }
+
+      resolve(record);
+    };
+
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function getAllDataCacheKeys(): Promise<string[]> {
+  const db = await getDatabase();
+
+  if (!db) {
+    return Array.from(memoryDataStore.keys());
+  }
+
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(DATA_STORE, "readonly");
+    const store = tx.objectStore(DATA_STORE);
+    const request = store.getAllKeys();
+
+    request.onsuccess = () => {
+      resolve((request.result as IDBValidKey[]).map(String));
+    };
+
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function enqueueRequest(
+  record: OfflineRequestRecord
+): Promise<void> {
+  const db = await getDatabase();
+
+  if (!db) {
+    memoryQueueStore.set(record.id, record);
+    return;
+  }
+
+  await runTransaction(db, QUEUE_STORE, "readwrite", (store) => {
+    store.put(record, record.id);
+  });
+}
+
+export async function getQueuedRequests(): Promise<OfflineRequestRecord[]> {
+  const db = await getDatabase();
+
+  if (!db) {
+    return Array.from(memoryQueueStore.values());
+  }
+
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(QUEUE_STORE, "readonly");
+    const store = tx.objectStore(QUEUE_STORE);
+    const request = store.getAll();
+
+    request.onsuccess = () => {
+      resolve((request.result as OfflineRequestRecord[]) ?? []);
+    };
+
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function removeQueuedRequest(id: string): Promise<void> {
+  const db = await getDatabase();
+
+  if (!db) {
+    memoryQueueStore.delete(id);
+    return;
+  }
+
+  await runTransaction(db, QUEUE_STORE, "readwrite", (store) => {
+    store.delete(id);
+  });
+}
+
+export async function updateQueuedRequest(
+  record: OfflineRequestRecord
+): Promise<void> {
+  await enqueueRequest(record);
+}

--- a/apps/pwa/src/lib/offline-graphql.ts
+++ b/apps/pwa/src/lib/offline-graphql.ts
@@ -1,0 +1,62 @@
+import type { RequestDocument, Variables } from "graphql-request";
+import { graphqlRequest } from "./graph-client";
+import {
+  cacheGraphQLResponse,
+  getCachedGraphQLResponse,
+} from "./offline-cache";
+
+export interface OfflineAwareResult<T> {
+  data: T;
+  source: "network" | "cache";
+  timestamp: number;
+  error?: unknown;
+}
+
+export async function graphqlRequestWithOffline<
+  TData,
+  TVars extends Variables = Variables,
+>(
+  document: RequestDocument,
+  variables?: TVars,
+  requestHeaders?: HeadersInit
+): Promise<OfflineAwareResult<TData>> {
+  try {
+    const data = await graphqlRequest<TData, TVars>(
+      document,
+      variables,
+      requestHeaders
+    );
+
+    let timestamp = Date.now();
+    try {
+      const record = await cacheGraphQLResponse<TData>(
+        document,
+        variables,
+        data
+      );
+      timestamp = record.timestamp;
+    } catch (cacheError) {
+      console.warn("Failed to cache GraphQL response", cacheError);
+    }
+
+    return {
+      data,
+      source: "network",
+      timestamp,
+    };
+  } catch (error) {
+    const cached = await getCachedGraphQLResponse<TData>(document, variables);
+    if (cached) {
+      console.warn("Serving GraphQL data from offline cache", error);
+      return {
+        data: cached.value,
+        source: "cache",
+        timestamp: cached.timestamp,
+        error,
+      };
+    }
+
+    throw error;
+  }
+}
+

--- a/apps/pwa/src/lib/offline-queue.ts
+++ b/apps/pwa/src/lib/offline-queue.ts
@@ -1,0 +1,167 @@
+import {
+  enqueueRequest,
+  getQueuedRequests,
+  removeQueuedRequest,
+  type OfflineRequestRecord,
+  updateQueuedRequest,
+} from "./offline-db";
+
+type SerializedFormDataEntry =
+  | {
+      kind: "string";
+      name: string;
+      value: string;
+    }
+  | {
+      kind: "blob";
+      name: string;
+      value: Blob;
+      filename?: string;
+    };
+
+export type SerializedRequestBody =
+  | { kind: "none" }
+  | { kind: "string"; value: string }
+  | { kind: "form-data"; entries: SerializedFormDataEntry[] }
+  | { kind: "blob"; value: Blob };
+
+export interface QueueRequestParams {
+  baseUrl: string;
+  path: string;
+  method: string;
+  headers: Record<string, string>;
+  body?: BodyInit | null;
+  requiresCsrf?: boolean;
+}
+
+export interface QueueResult {
+  queued: boolean;
+  id: string;
+  queuedAt: number;
+}
+
+function generateQueueId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function isFormData(value: unknown): value is FormData {
+  return typeof FormData !== "undefined" && value instanceof FormData;
+}
+
+function isBlob(value: unknown): value is Blob {
+  return typeof Blob !== "undefined" && value instanceof Blob;
+}
+
+function isFile(value: unknown): value is File {
+  return typeof File !== "undefined" && value instanceof File;
+}
+
+export function serializeRequestBody(
+  body: BodyInit | null | undefined
+): SerializedRequestBody {
+  if (!body) {
+    return { kind: "none" };
+  }
+
+  if (typeof body === "string") {
+    return { kind: "string", value: body };
+  }
+
+  if (isFormData(body)) {
+    const entries: SerializedFormDataEntry[] = [];
+    body.forEach((value, name) => {
+      if (typeof value === "string") {
+        entries.push({ kind: "string", name, value });
+      } else if (isBlob(value)) {
+        entries.push({
+          kind: "blob",
+          name,
+          value,
+          filename: isFile(value) ? value.name : undefined,
+        });
+      }
+    });
+
+    return { kind: "form-data", entries };
+  }
+
+  if (isBlob(body)) {
+    return { kind: "blob", value: body };
+  }
+
+  return { kind: "string", value: String(body) };
+}
+
+export function deserializeRequestBody(
+  serialized: SerializedRequestBody | undefined
+): BodyInit | undefined {
+  if (!serialized || serialized.kind === "none") {
+    return undefined;
+  }
+
+  if (serialized.kind === "string") {
+    return serialized.value;
+  }
+
+  if (serialized.kind === "blob") {
+    return serialized.value;
+  }
+
+  if (serialized.kind === "form-data") {
+    const formData = new FormData();
+    serialized.entries.forEach((entry) => {
+      if (entry.kind === "string") {
+        formData.append(entry.name, entry.value);
+      } else {
+        formData.append(entry.name, entry.value, entry.filename);
+      }
+    });
+    return formData;
+  }
+
+  return undefined;
+}
+
+export async function queueRequest(
+  params: QueueRequestParams
+): Promise<QueueResult> {
+  const id = generateQueueId();
+  const queuedAt = Date.now();
+
+  const record: OfflineRequestRecord = {
+    id,
+    baseUrl: params.baseUrl,
+    path: params.path,
+    method: params.method,
+    body: serializeRequestBody(params.body ?? undefined),
+    headers: params.headers,
+    queuedAt,
+    attempts: 0,
+    requiresCsrf: params.requiresCsrf,
+  };
+
+  await enqueueRequest(record);
+
+  return { queued: true, id, queuedAt } satisfies QueueResult;
+}
+
+export async function readQueuedRequests(): Promise<OfflineRequestRecord[]> {
+  const records = await getQueuedRequests();
+  return records.sort((a, b) => a.queuedAt - b.queuedAt);
+}
+
+export async function markRequestAsFailed(
+  record: OfflineRequestRecord,
+  error: unknown
+): Promise<void> {
+  record.attempts += 1;
+  record.lastError = error instanceof Error ? error.message : String(error);
+  await updateQueuedRequest(record);
+}
+
+export async function dropQueuedRequest(id: string): Promise<void> {
+  await removeQueuedRequest(id);
+}

--- a/apps/pwa/src/lib/offline-status.ts
+++ b/apps/pwa/src/lib/offline-status.ts
@@ -1,0 +1,51 @@
+import { useOfflineStore } from "../stores/offline-store";
+import { readQueuedRequests } from "./offline-queue";
+
+let listenersInitialized = false;
+
+export function initializeOfflineStatusListeners(baseUrl?: string): void {
+  if (listenersInitialized || typeof window === "undefined") {
+    return;
+  }
+
+  const resolvedBaseUrl = baseUrl || window.location.origin;
+
+  const updateOnlineStatus = () => {
+    useOfflineStore.getState().setOnline(navigator.onLine);
+  };
+
+  const handleQueueUpdate = (event: Event) => {
+    const customEvent = event as CustomEvent<{
+      count: number;
+      timestamp?: number;
+    }>;
+    if (!customEvent.detail) return;
+    const { count, timestamp } = customEvent.detail;
+    useOfflineStore.getState().setQueuedCount(count, timestamp);
+  };
+
+  window.addEventListener("online", updateOnlineStatus);
+  window.addEventListener("offline", updateOnlineStatus);
+  window.addEventListener(
+    "khp:offline-queue",
+    handleQueueUpdate as EventListener
+  );
+
+  updateOnlineStatus();
+
+  readQueuedRequests()
+    .then((records) => {
+      const count = records.filter(
+        (record) => record.baseUrl === resolvedBaseUrl
+      ).length;
+      useOfflineStore
+        .getState()
+        .setQueuedCount(count, count === 0 ? Date.now() : undefined);
+    })
+    .catch((error) => {
+      console.warn("Failed to hydrate offline queue state", error);
+    });
+
+  listenersInitialized = true;
+}
+

--- a/apps/pwa/src/lib/prefetch.ts
+++ b/apps/pwa/src/lib/prefetch.ts
@@ -1,0 +1,40 @@
+import {
+  GetCategoriesDocument,
+  GetCompanyProductsDocument,
+  GetLocationsDocument,
+  type GetCompanyProductsQueryVariables,
+} from "@workspace/graphql";
+import { graphqlRequestWithOffline } from "./offline-graphql";
+
+const PREFETCH_KEY = "khp:last-prefetch";
+const PREFETCH_TTL = 1000 * 60 * 15; // 15 minutes
+
+export async function prefetchEssentialData(options?: {
+  force?: boolean;
+}): Promise<void> {
+  if (typeof window === "undefined") return;
+  if (typeof navigator !== "undefined" && !navigator.onLine) return;
+
+  const force = options?.force ?? false;
+  const lastPrefetch = window.localStorage.getItem(PREFETCH_KEY);
+
+  if (!force && lastPrefetch) {
+    const elapsed = Date.now() - Number(lastPrefetch);
+    if (!Number.isNaN(elapsed) && elapsed < PREFETCH_TTL) {
+      return;
+    }
+  }
+
+  const tasks: Array<Promise<unknown>> = [
+    graphqlRequestWithOffline(GetLocationsDocument),
+    graphqlRequestWithOffline(GetCategoriesDocument),
+    graphqlRequestWithOffline(
+      GetCompanyProductsDocument,
+      { page: 1 } satisfies GetCompanyProductsQueryVariables
+    ),
+  ];
+
+  await Promise.allSettled(tasks);
+
+  window.localStorage.setItem(PREFETCH_KEY, String(Date.now()));
+}

--- a/apps/pwa/src/main.tsx
+++ b/apps/pwa/src/main.tsx
@@ -8,6 +8,16 @@ import "@workspace/ui/globals.css";
 import { Guard } from "./components/guard-device";
 import PWABadge from "./PWABadge";
 import MobileInstallBanner from "./components/MobileInstallBanner";
+import api from "./lib/api";
+import { initializeOfflineStatusListeners } from "./lib/offline-status";
+
+if (typeof navigator === "undefined" || navigator.onLine) {
+  void api.flushOfflineQueue().catch((error) => {
+    console.error("Failed to flush offline queue on startup", error);
+  });
+}
+
+initializeOfflineStatusListeners(api.getBaseUrl());
 
 export const router = createRouter({ routeTree });
 declare module "@tanstack/react-router" {

--- a/apps/pwa/src/pages/Inventory.tsx
+++ b/apps/pwa/src/pages/Inventory.tsx
@@ -12,7 +12,7 @@ import { ScanBarcode } from "lucide-react";
 import type { GetCompanyProductsQuery } from "@workspace/graphql";
 
 function InventoryPage() {
-  const { data, pageInfo } = useLoaderData({
+  const { data, pageInfo, source, cacheTimestamp, status } = useLoaderData({
     from: "/_protected/inventory",
   });
   const { search_terms = "", pageIndex } = useSearch({
@@ -55,7 +55,7 @@ function InventoryPage() {
   const sentinelRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     const el = sentinelRef.current;
-    if (!el || !pageInfo.hasMorePages) return;
+    if (!el || !pageInfo.hasMorePages || status === "missing-offline") return;
 
     const observer = new IntersectionObserver(
       ([entry]) => {
@@ -74,10 +74,28 @@ function InventoryPage() {
 
     observer.observe(el);
     return () => observer.disconnect();
-  }, [pageInfo.hasMorePages, pageIndex, debouncedTerm, navigate]);
+  }, [pageInfo.hasMorePages, pageIndex, debouncedTerm, navigate, status]);
+
+  const isOfflineData = source === "cache";
+  const isOfflineUnavailable = status === "missing-offline";
+  const lastUpdatedLabel = cacheTimestamp
+    ? new Date(cacheTimestamp).toLocaleString()
+    : null;
 
   return (
     <div className="space-y-4">
+      {isOfflineUnavailable && (
+        <div className="bg-amber-100 text-amber-900 border border-amber-200 px-3 py-2 rounded-md text-sm">
+          Impossible de récupérer d'autres ingrédients hors connexion. Réessaye
+          une fois la connexion rétablie.
+        </div>
+      )}
+      {isOfflineData && (
+        <div className="bg-amber-100 text-amber-900 border border-amber-200 px-3 py-2 rounded-md text-sm">
+          Données consultées hors connexion
+          {lastUpdatedLabel && ` — mise à jour le ${lastUpdatedLabel}`}.
+        </div>
+      )}
       <div className="fixed bottom-4 left-1/2 transform -translate-x-1/2 max-w-md bg-background p-4 rounded shadow-lg w-11/12 flex gap-2">
         <Input
           type="text"

--- a/apps/pwa/src/pages/ProductHistory.tsx
+++ b/apps/pwa/src/pages/ProductHistory.tsx
@@ -35,6 +35,8 @@ interface LoaderData {
   };
   currentFilter: string;
   currentSelectedMonth?: string;
+  source?: "network" | "cache";
+  cacheTimestamp?: number;
 }
 
 type FilterPreset = "all" | "today" | "week" | "month";
@@ -56,7 +58,14 @@ export default function ProductHistoryPage() {
     paginatorInfo,
     currentFilter,
     currentSelectedMonth,
+    source,
+    cacheTimestamp,
   } = loaderData;
+
+  const isOfflineData = source === "cache";
+  const lastUpdatedLabel = cacheTimestamp
+    ? new Date(cacheTimestamp).toLocaleString()
+    : null;
 
   console.log("🎯 ProductHistory data:", {
     product,
@@ -167,6 +176,12 @@ export default function ProductHistoryPage() {
   return (
     <div className="pb-20">
       <div className="sticky top-16 z-90 flex flex-col gap-4 p-2 bg-khp-background">
+        {isOfflineData && (
+          <div className="bg-amber-100 text-amber-900 border border-amber-200 px-3 py-2 rounded-md text-sm">
+            Données consultées hors connexion
+            {lastUpdatedLabel && ` — mise à jour le ${lastUpdatedLabel}`}.
+          </div>
+        )}
         <div className="flex justify-between items-center">
           <h2 className="text-xl font-semibold">{product.name}</h2>
           <Button

--- a/apps/pwa/src/pages/handleItem/addProduct/HandleAddProduct.tsx
+++ b/apps/pwa/src/pages/handleItem/addProduct/HandleAddProduct.tsx
@@ -27,6 +27,7 @@ import { Minus, Plus } from "lucide-react";
 import { handleItemSchema } from "./handleItemSchema";
 import { ImageAdd } from "@workspace/ui/components/image-placeholder";
 import { extractApiErrorMessage } from "../../../lib/error-utils";
+import type { WantedDataType } from "../../../lib/handleScanType";
 import { WANTED_IMAGE_SIZE } from "@workspace/ui/lib/const";
 import { compressImageFile } from "@workspace/ui/lib/compress-img";
 
@@ -35,9 +36,61 @@ function HandleAddProduct() {
   const { barcode, internalId } = useSearch({
     from: "/_protected/handle-item",
   });
-  const { product, type, availableLocations, categories } = useLoaderData({
-    from: "/_protected/handle-item",
-  });
+  const { product, type, availableLocations, categories, dataSources, status } =
+    useLoaderData({
+      from: "/_protected/handle-item",
+    }) as {
+      product: WantedDataType | null;
+      type: z.infer<typeof handleItemSchema>["type"];
+      availableLocations: Array<{
+        id: string;
+        name: string;
+        locationType?: { id: string; name: string; is_default: boolean } | null;
+      }>;
+      categories: Array<{ id: string; name: string }>;
+      dataSources: Record<string, { source: string; timestamp: number | null }>;
+      status?: "ok" | "missing-offline";
+    };
+
+  if (status === "missing-offline") {
+    return (
+      <div className="flex min-h-[75svh] flex-col items-center justify-center gap-4 p-6 text-center">
+        <p className="text-sm text-muted-foreground">
+          La création d'un produit hors connexion nécessite une synchronisation
+          préalable (catégories et localisations). Réessaye quand la connexion
+          est disponible.
+        </p>
+        <Button
+          variant="khp-default"
+          onClick={() =>
+            navigate({
+              to: "/inventory",
+              replace: true,
+            })
+          }
+        >
+          Retour à l'inventaire
+        </Button>
+      </div>
+    );
+  }
+
+  const locationsSource = dataSources?.locations?.source;
+  const categoriesSource = dataSources?.categories?.source;
+
+  const effectiveLocations: typeof availableLocations =
+    availableLocations?.length === 0
+      ? ((product?.quantities || [])
+          .map((qty) => qty.location)
+          .filter(
+            (loc): loc is NonNullable<typeof loc> => loc != null
+          )
+          .map((loc) => ({
+            id: loc.id,
+            name: loc.name,
+            locationType: loc.locationType ?? null,
+          })) as unknown as typeof availableLocations)
+      : availableLocations;
 
   const [filePreview, setFilePreview] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -47,10 +100,16 @@ function HandleAddProduct() {
     (unit) => unit.value === "unit"
   )?.value;
 
-  const form = useForm<z.infer<typeof handleItemSchema>>({
+  const typedType = type as z.infer<typeof handleItemSchema>["type"];
+
+  const form = useForm<
+    z.infer<typeof handleItemSchema>,
+    undefined,
+    z.infer<typeof handleItemSchema>
+  >({
     resolver: zodResolver(handleItemSchema),
     defaultValues: {
-      type: type,
+      type: typedType,
       image: undefined,
       product_name: product?.product_name,
       product_category:
@@ -128,6 +187,18 @@ function HandleAddProduct() {
           onSubmit={form.handleSubmit(onSubmit)}
           className="space-y-4 flex flex-col items-center px-4 w-full max-w-md"
         >
+          {locationsSource === "missing-offline" && (
+            <div className="bg-amber-100 text-amber-900 border border-amber-200 px-3 py-2 rounded-md text-sm text-center w-full">
+              Les localisations n'ont pas été entièrement synchronisées hors
+              connexion. Seules celles déjà connues sont proposées.
+            </div>
+          )}
+          {categoriesSource === "missing-offline" && (
+            <div className="bg-amber-100 text-amber-900 border border-amber-200 px-3 py-2 rounded-md text-sm text-center w-full">
+              Les catégories n'ont pas pu être chargées hors connexion. Tu pourras
+              en sélectionner une quand la connexion sera rétablie.
+            </div>
+          )}
           <FormField
             control={form.control}
             name="image"
@@ -191,6 +262,7 @@ function HandleAddProduct() {
                   <Select
                     onValueChange={field.onChange}
                     defaultValue={field.value}
+                    disabled={categories?.length === 0}
                   >
                     <FormControl>
                       <SelectTrigger className="w-full border-khp-primary rounded-md px-4 py-6 truncate">
@@ -198,19 +270,13 @@ function HandleAddProduct() {
                       </SelectTrigger>
                     </FormControl>
                     <SelectContent>
-                      {categories &&
-                        categories.map(
-                          (categorie: { id: string; name: string }) => {
-                            return (
-                              <SelectItem
-                                key={categorie.id}
-                                value={categorie.id}
-                              >
-                                {categorie.name}
-                              </SelectItem>
-                            );
-                          }
-                        )}
+                      {categories?.map(
+                        (categorie: { id: string; name: string }) => (
+                          <SelectItem key={categorie.id} value={categorie.id}>
+                            {categorie.name}
+                          </SelectItem>
+                        )
+                      )}
                     </SelectContent>
                   </Select>
                   <FormMessage />
@@ -330,7 +396,7 @@ function HandleAddProduct() {
                           </SelectTrigger>
                         </FormControl>
                         <SelectContent>
-                          {availableLocations.map(
+                          {effectiveLocations.map(
                             (location: { id: string; name: string }) => (
                               <SelectItem key={location.id} value={location.id}>
                                 {location.name}

--- a/apps/pwa/src/pages/handleItem/movequantity/MoveQuantity.tsx
+++ b/apps/pwa/src/pages/handleItem/movequantity/MoveQuantity.tsx
@@ -18,12 +18,71 @@ import { useForm } from "react-hook-form";
 import z from "zod";
 import { moveQuantitySchema } from "./moveQuantitySchema";
 import moveQuantitySubmit from "./move-quantity";
+import type { WantedDataType } from "../../../lib/handleScanType";
 
 function MoveQuantity() {
   const navigate = useNavigate();
-  const { product, availableLocations } = useLoaderData({
+  const {
+    product,
+    availableLocations,
+    dataSources,
+    status,
+  } = useLoaderData({
     from: "/_protected/move-quantity",
-  });
+  }) as {
+    product: WantedDataType | null;
+    availableLocations: Array<{
+      id: string;
+      name: string;
+      locationType?: { id: string; name: string; is_default: boolean } | null;
+    }>;
+    dataSources: Record<string, { source: string; timestamp: number | null }>;
+    status?: "ok" | "missing-offline";
+  };
+
+  if (!product || status === "missing-offline") {
+    return (
+      <div className="flex min-h-[75svh] flex-col items-center justify-center gap-4 p-6 text-center">
+        <p className="text-sm text-muted-foreground">
+          Impossible de déplacer des quantités hors connexion pour ce produit.
+          Ouvre-le en ligne au moins une fois pour le synchroniser.
+        </p>
+        <Button
+          variant="khp-default"
+          onClick={() =>
+            navigate({
+              to: "/inventory",
+              replace: true,
+            })
+          }
+        >
+          Retour à l'inventaire
+        </Button>
+      </div>
+    );
+  }
+
+  const productSource = dataSources?.product;
+  const locationsSource = dataSources?.locations;
+  const isOfflineData =
+    productSource?.source === "cache" || locationsSource?.source === "cache";
+  const lastUpdatedLabel = productSource?.timestamp
+    ? new Date(productSource.timestamp).toLocaleString()
+    : null;
+
+  const fallbackLocations: typeof availableLocations =
+    availableLocations.length === 0
+      ? ((product.quantities || [])
+          .map((qty) => qty.location)
+          .filter(
+            (loc): loc is NonNullable<typeof loc> => loc != null
+          )
+          .map((loc) => ({
+            id: loc.id,
+            name: loc.name,
+            locationType: loc.locationType ?? null,
+          })) as unknown as typeof availableLocations)
+      : availableLocations;
 
   const form = useForm<z.infer<typeof moveQuantitySchema>>({
     resolver: zodResolver(moveQuantitySchema),
@@ -46,6 +105,18 @@ function MoveQuantity() {
           onSubmit={form.handleSubmit(onSubmit)}
           className="space-y-4 flex flex-col items-center px-4 w-full max-w-md"
         >
+          {locationsSource?.source === "missing-offline" && (
+            <div className="bg-amber-100 text-amber-900 border border-amber-200 px-3 py-2 rounded-md text-sm text-center w-full">
+              Certaines localisations n'ont pas pu être chargées hors connexion.
+              Seules celles déjà synchronisées sont disponibles.
+            </div>
+          )}
+          {isOfflineData && (
+            <div className="bg-amber-100 text-amber-900 border border-amber-200 px-3 py-2 rounded-md text-sm text-center w-full">
+              Données produit disponibles hors connexion
+              {lastUpdatedLabel && ` — mise à jour le ${lastUpdatedLabel}`}.
+            </div>
+          )}
           <img
             src={
               product?.product_image ||
@@ -107,7 +178,7 @@ function MoveQuantity() {
               name="destination_id"
               render={({ field }) => (
                 <LocationSelect
-                  quantities={locationSelectMapper(availableLocations) || []}
+                  quantities={locationSelectMapper(fallbackLocations) || []}
                   value={field.value}
                   onValueChange={field.onChange}
                   placeholder="Select destination location"

--- a/apps/pwa/src/routes/_protected/inventory.tsx
+++ b/apps/pwa/src/routes/_protected/inventory.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import InventoryPage from "../../pages/Inventory";
-import { graphqlRequest } from "../../lib/graph-client";
+import { graphqlRequestWithOffline } from "../../lib/offline-graphql";
 import {
   GetCompanyProductsDocument,
   type GetCompanyProductsQuery,
@@ -24,15 +24,43 @@ export const Route = createFileRoute("/_protected/inventory")({
       variables.searchQuery = search_terms.trim();
     }
 
-    const result = await graphqlRequest<GetCompanyProductsQuery>(
-      GetCompanyProductsDocument,
-      variables
-    );
+    try {
+      const { data: result, source, timestamp } =
+        await graphqlRequestWithOffline<GetCompanyProductsQuery>(
+          GetCompanyProductsDocument,
+          variables
+        );
 
-    return {
-      data: result.ingredients.data ?? [],
-      pageInfo: result.ingredients.paginatorInfo,
-    };
+      return {
+        data: result.ingredients.data ?? [],
+        pageInfo: result.ingredients.paginatorInfo,
+        source,
+        cacheTimestamp: timestamp,
+        status: "ok" as const,
+      };
+    } catch (error) {
+      const isOffline = typeof navigator !== "undefined" && !navigator.onLine;
+      if (!isOffline) {
+        throw error;
+      }
+
+      const fallbackPageInfo = {
+        hasMorePages: false,
+        currentPage: pageIndex,
+        lastPage: pageIndex,
+        total: 0,
+        count: 0,
+        perPage: 0,
+      } as GetCompanyProductsQuery["ingredients"]["paginatorInfo"];
+
+      return {
+        data: [] as GetCompanyProductsQuery["ingredients"]["data"],
+        pageInfo: fallbackPageInfo,
+        source: "missing-offline" as const,
+        cacheTimestamp: null,
+        status: "missing-offline" as const,
+      };
+    }
   },
   component: InventoryPage,
 });

--- a/apps/pwa/src/routes/_protected/products.$id.tsx
+++ b/apps/pwa/src/routes/_protected/products.$id.tsx
@@ -1,23 +1,60 @@
 import { createFileRoute } from "@tanstack/react-router";
 import ProductPage from "../../pages/Product";
-import { graphqlRequest } from "../../lib/graph-client";
+import { graphqlRequestWithOffline } from "../../lib/offline-graphql";
 import { GetProductDocument, type GetProductQuery } from "@workspace/graphql";
+import { mapIngredientToWantedData } from "../../lib/handleScanType";
+import { saveIngredientSnapshot } from "../../lib/ingredient-cache";
 
 export const Route = createFileRoute("/_protected/products/$id")({
   loader: async ({ params }) => {
-    const result = await graphqlRequest<GetProductQuery>(GetProductDocument, {
-      id: params.id,
-    });
+    let result: GetProductQuery | null = null;
+    let source: "network" | "cache" = "network";
+    let timestamp = Date.now();
+    let offlineMiss = false;
 
-    if (!result.ingredient) {
+    try {
+      const response = await graphqlRequestWithOffline<GetProductQuery>(
+        GetProductDocument,
+        {
+          id: params.id,
+        }
+      );
+      result = response.data;
+      source = response.source;
+      timestamp = response.timestamp;
+    } catch (error) {
+      const isOffline = typeof navigator !== "undefined" && !navigator.onLine;
+      if (!isOffline) {
+        throw error;
+      }
+      offlineMiss = true;
+    }
+
+    if (!result?.ingredient) {
+      if (offlineMiss) {
+        return {
+          data: null,
+          meta: {
+            id: params.id,
+            loadedAt: null,
+            source: "missing-offline" as const,
+            cacheTimestamp: null,
+          },
+        };
+      }
       throw new Error(`Product with ID ${params.id} not found`);
     }
+
+    const normalized = mapIngredientToWantedData(result.ingredient);
+    await saveIngredientSnapshot(normalized);
 
     return {
       data: result.ingredient,
       meta: {
         id: params.id,
-        loadedAt: new Date().toISOString(),
+        loadedAt: new Date(timestamp).toISOString(),
+        source,
+        cacheTimestamp: timestamp,
       },
     };
   },

--- a/apps/pwa/src/routes/_protected/products.$id_.history.tsx
+++ b/apps/pwa/src/routes/_protected/products.$id_.history.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import ProductHistoryPage from "../../pages/ProductHistory";
-import { graphqlRequest } from "../../lib/graph-client";
+import { graphqlRequestWithOffline } from "../../lib/offline-graphql";
 import { GetProductDocument, type GetProductQuery } from "@workspace/graphql";
 
 import z from "zod";
@@ -20,9 +20,13 @@ export const Route = createFileRoute("/_protected/products/$id_/history")({
     const { id } = params;
     const { filter, selectedMonth } = deps;
 
-    const productData = await graphqlRequest<GetProductQuery>(GetProductDocument, {
-      id,
-    });
+    const { data: productData, source, timestamp } =
+      await graphqlRequestWithOffline<GetProductQuery>(
+        GetProductDocument,
+        {
+          id,
+        }
+      );
 
     if (!productData.ingredient) {
       throw new Error("Product not found");
@@ -103,6 +107,8 @@ export const Route = createFileRoute("/_protected/products/$id_/history")({
       },
       currentFilter: filter,
       currentSelectedMonth: selectedMonth,
+      source,
+      cacheTimestamp: timestamp,
     };
   },
   component: ProductHistoryPage,

--- a/apps/pwa/src/stores/offline-store.ts
+++ b/apps/pwa/src/stores/offline-store.ts
@@ -1,0 +1,26 @@
+import { create } from "zustand";
+
+type OfflineState = {
+  isOnline: boolean;
+  queuedCount: number;
+  lastSyncedAt: number | null;
+  setOnline: (isOnline: boolean) => void;
+  setQueuedCount: (count: number, timestamp?: number) => void;
+};
+
+const initialOnlineState =
+  typeof navigator !== "undefined" ? navigator.onLine : true;
+
+export const useOfflineStore = create<OfflineState>((set) => ({
+  isOnline: initialOnlineState,
+  queuedCount: 0,
+  lastSyncedAt: null,
+  setOnline: (isOnline) => set({ isOnline }),
+  setQueuedCount: (queuedCount, timestamp) =>
+    set((state) => ({
+      queuedCount,
+      lastSyncedAt:
+        queuedCount === 0 && timestamp ? timestamp : state.lastSyncedAt,
+    })),
+}));
+

--- a/apps/pwa/src/ui/LoginForm.tsx
+++ b/apps/pwa/src/ui/LoginForm.tsx
@@ -10,6 +10,7 @@ import {
 import { Input } from "@workspace/ui/components/input";
 import { Label } from "@workspace/ui/components/label";
 import api from "../lib/api";
+import { prefetchEssentialData } from "../lib/prefetch";
 import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import { Loader2 } from "lucide-react";
@@ -34,12 +35,21 @@ export function LoginForm({
         password,
       });
 
+      if (typeof window !== "undefined") {
+        localStorage.setItem("khp:last-authenticated", "true");
+      }
+
+      void prefetchEssentialData({ force: true });
+
       navigate({
         to: "/inventory",
         replace: true,
       });
     } catch (error) {
       console.error("Login failed:", error);
+      if (typeof window !== "undefined") {
+        localStorage.removeItem("khp:last-authenticated");
+      }
     } finally {
       setIsLoading(false);
     }

--- a/apps/pwa/src/utils/hash.ts
+++ b/apps/pwa/src/utils/hash.ts
@@ -1,0 +1,21 @@
+/**
+ * Lightweight non-cryptographic string hash inspired by cyrb53.
+ * Produces a stable base-36 string suitable for cache keys.
+ */
+export function hashString(input: string): string {
+  let h1 = 0xdeadbeef ^ input.length;
+  let h2 = 0x41c6ce57 ^ input.length;
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input.charCodeAt(i);
+    h1 = Math.imul(h1 ^ ch, 2654435761);
+    h2 = Math.imul(h2 ^ ch, 1597334677);
+  }
+
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+
+  const combined = 4294967296 * (2097151 & h2) + (h1 >>> 0);
+  return combined.toString(36);
+}
+

--- a/packages/graphql/src/schema/schema.graphql
+++ b/packages/graphql/src/schema/schema.graphql
@@ -1,3 +1,21 @@
+enum UnitEnum {
+  kg
+  hg
+  dag
+  g
+  dg
+  cg
+  mg
+  kL
+  hL
+  daL
+  L
+  dL
+  cL
+  mL
+  unit
+}
+
 enum AllergenEnum {
   gluten
   fruits_a_coque
@@ -15,682 +33,9 @@ enum AllergenEnum {
   mollusques
 }
 
-type Category {
-  """Unique primary key."""
-  id: ID!
-
-  """Category name."""
-  name: String!
-
-  """Ingredients in this category."""
-  ingredients: [Ingredient!]!
-
-  """Preparations in this category."""
-  preparations: [Preparation!]!
-
-  """The company that owns this category."""
-  company: Company!
-
-  """Shelf life durations by location type."""
-  shelfLives: [CategoryShelfLife!]!
-
-  """When the Category was created."""
-  created_at: DateTime!
-
-  """When the Category was last updated."""
-  updated_at: DateTime!
-}
-
-"""A paginated list of Category items."""
-type CategoryPaginator {
-  """Pagination information about the list of items."""
-  paginatorInfo: PaginatorInfo!
-
-  """A list of Category items."""
-  data: [Category!]!
-}
-
-type CategoryShelfLife {
-  """The location type for this shelf life."""
-  locationType: LocationType!
-
-  """Shelf life in hours for the category at this location type."""
-  shelf_life_hours: Int!
-}
-
-type Company {
-  """Unique primary key."""
-  id: ID!
-
-  """Company name."""
-  name: String!
-
-  """Preparations associated with this company."""
-  preparations: [Preparation!]!
-  categories: [Category!]!
-  locations: [Location!]!
-
-  """Types de localisation associés à cette entreprise."""
-  locationTypes: [LocationType!]!
-
-  """Langue préférée pour les données OpenFoodFacts (fr ou en)."""
-  open_food_facts_language: String
-
-  """Paramètres visibles publiquement pour la carte des menus."""
-  public_menu_settings: PublicMenuSettings!
-
-  """Logo ou image de présentation de l'entreprise."""
-  logo_path: String
-
-  """Nom de la personne à contacter."""
-  contact_name: String
-
-  """Adresse e-mail de contact."""
-  contact_email: String
-
-  """Numéro de téléphone principal."""
-  contact_phone: String
-
-  """Ligne d'adresse principale."""
-  address_line: String
-
-  """Code postal."""
-  postal_code: String
-
-  """Ville."""
-  city: String
-
-  """Pays."""
-  country: String
-
-  """Horaires d'ouverture de la semaine."""
-  businessHours: [CompanyBusinessHour!]!
-
-  """When the company was created."""
-  created_at: DateTime!
-
-  """When the company was last updated."""
-  updated_at: DateTime!
-}
-
-type CompanyBusinessHour {
-  id: ID!
-  day_of_week: Int!
-  opens_at: String!
-  closes_at: String!
-  is_overnight: Boolean!
-  sequence: Int!
-  created_at: DateTime!
-  updated_at: DateTime!
-}
-
-"""Champs disponibles pour le tri des entreprises."""
-enum CompanyOrderByField {
-  ID
-  NAME
-  CREATED_AT
-  UPDATED_AT
-}
-
-"""Options de tri pour les entreprises."""
-input CompanyOrderByOrderByClause {
-  """Champ sur lequel effectuer le tri."""
-  field: CompanyOrderByField!
-
-  """Direction du tri."""
-  order: SortOrder!
-}
-
-"""A paginated list of Company items."""
-type CompanyPaginator {
-  """Pagination information about the list of items."""
-  paginatorInfo: PaginatorInfo!
-
-  """A list of Company items."""
-  data: [Company!]!
-}
-
-scalar Date
-
-"""
-A datetime string with format `Y-m-d H:i:s`, e.g. `2018-05-23 13:43:32`.
-"""
-scalar DateTime
-
-type Ingredient {
-  """Unique primary key."""
-  id: ID!
-
-  """Ingredient name."""
-  name: String!
-
-  """Unit of measurement for the ingredient."""
-  unit: UnitEnum!
-
-  """Quantity for one unit of the ingredient."""
-  base_quantity: Float!
-
-  """Unit for the base quantity of the ingredient."""
-  base_unit: UnitEnum!
-
-  """Optional minimum stock quantity before alerting."""
-  threshold: Float
-
-  """Allergens contained in the ingredient."""
-  allergens: [AllergenEnum!]!
-  quantities: [IngredientQuantity!]!
-
-  """The company that owns this ingredient."""
-  company: Company!
-  category: Category!
-  image_url: String
-
-  """Historique des mouvements de stock pour cet ingrédient"""
-  stockMovements(orderBy: [StockMovementOrderByClause!]): [StockMovement!]!
-  withdrawals_today_count: Int!
-
-  """Number of withdrawals for this ingredient today."""
-  withdrawals_this_week_count: Int!
-
-  """Number of withdrawals for this ingredient this week."""
-  withdrawals_this_month_count: Int!
-
-  """When the ingredient was created."""
-  created_at: DateTime!
-
-  """When the ingredient was last updated."""
-  updated_at: DateTime!
-}
-
-input IngredientOrderByClause {
-  column: IngredientOrderByField!
-  order: SortOrder! = ASC
-}
-
-enum IngredientOrderByField {
-  ID
-  NAME
-  CREATED_AT
-  UPDATED_AT
-  WITHDRAWALS_TODAY
-  WITHDRAWALS_THIS_WEEK
-  WITHDRAWALS_THIS_MONTH
-}
-
-"""A paginated list of Ingredient items."""
-type IngredientPaginator {
-  """Pagination information about the list of items."""
-  paginatorInfo: PaginatorInfo!
-
-  """A list of Ingredient items."""
-  data: [Ingredient!]!
-}
-
-type IngredientQuantity {
-  """Le stock de l'ingrédient."""
-  quantity: Float!
-
-  """La localisation de ce stock."""
-  location: Location!
-}
-
-scalar JSON
-
-type Location {
-  """Unique primary key."""
-  id: ID!
-
-  """Location name."""
-  name: String!
-
-  """Location company."""
-  company: Company!
-
-  """Type de localisation (Congélateur, Réfrigérateur, etc.)"""
-  locationType: LocationType
-
-  """When the location was created."""
-  created_at: DateTime!
-
-  """When the location was last updated."""
-  updated_at: DateTime!
-
-  """Ingredients stored in this location."""
-  ingredients: [Ingredient!]!
-}
-
-"""Champs disponibles pour le tri des emplacements."""
-enum LocationOrderByField {
-  ID
-  NAME
-  CREATED_AT
-  UPDATED_AT
-}
-
-"""Options de tri pour les emplacements."""
-input LocationOrderByOrderByClause {
-  """Champ sur lequel effectuer le tri."""
-  field: LocationOrderByField!
-
-  """Direction du tri."""
-  order: SortOrder!
-}
-
-"""A paginated list of Location items."""
-type LocationPaginator {
-  """Pagination information about the list of items."""
-  paginatorInfo: PaginatorInfo!
-
-  """A list of Location items."""
-  data: [Location!]!
-}
-
-"""Type de localisation pour organiser les emplacements de stockage"""
-type LocationType {
-  """Identifiant unique."""
-  id: ID!
-
-  """Nom du type de localisation."""
-  name: String!
-
-  """Indique si c'est un type par défaut (non modifiable)."""
-  is_default: Boolean!
-
-  """L'entreprise à laquelle appartient ce type."""
-  company: Company!
-
-  """Emplacements utilisant ce type de localisation."""
-  locations: [Location!]!
-
-  """Date de création du type."""
-  created_at: DateTime!
-
-  """Date de dernière mise à jour du type."""
-  updated_at: DateTime!
-}
-
-"""Champs disponibles pour le tri des types de localisation."""
-enum LocationTypeOrderByField {
-  ID
-  NAME
-  IS_DEFAULT
-  CREATED_AT
-  UPDATED_AT
-}
-
-"""Options de tri pour les types de localisation."""
-input LocationTypeOrderByOrderByClause {
-  """Champ sur lequel effectuer le tri."""
-  field: LocationTypeOrderByField!
-
-  """Direction du tri."""
-  order: SortOrder!
-}
-
-"""A paginated list of LocationType items."""
-type LocationTypePaginator {
-  """Pagination information about the list of items."""
-  paginatorInfo: PaginatorInfo!
-
-  """A list of LocationType items."""
-  data: [LocationType!]!
-}
-
-"""Représente une perte d'ingrédient ou de préparation."""
-type Loss {
-  """Identifiant unique."""
-  id: ID!
-
-  """Type d'entité concernée par cette perte (ingredient ou preparation)."""
-  loss_item_type: String!
-
-  """ID de l'entité concernée."""
-  loss_item_id: ID!
-
-  """L'emplacement où la perte a eu lieu."""
-  location: Location!
-
-  """L'entreprise à laquelle appartient cette perte."""
-  company: Company!
-
-  """L'utilisateur qui a enregistré la perte."""
-  user: User
-
-  """Quantité perdue."""
-  quantity: Float!
-
-  """Raison de la perte."""
-  reason: String!
-
-  """Date et heure de création de la perte."""
-  created_at: DateTime!
-
-  """Date et heure de dernière mise à jour de la perte."""
-  updated_at: DateTime!
-}
-
-"""Statistiques des pertes par type."""
-type LossesStats {
-  ingredient: Float!
-  preparation: Float!
-  total: Float!
-}
-
-input LossOrderByClause {
-  field: LossOrderByField!
-  order: SortOrder!
-}
-
-enum LossOrderByField {
-  ID
-  QUANTITY
-  CREATED_AT
-  UPDATED_AT
-}
-
-"""A paginated list of Loss items."""
-type LossPaginator {
-  """Pagination information about the list of items."""
-  paginatorInfo: PaginatorInfo!
-
-  """A list of Loss items."""
-  data: [Loss!]!
-}
-
-"""Raison de perte prédéfinie pour une entreprise."""
-type LossReason {
-  """Identifiant unique."""
-  id: ID!
-
-  """Nom de la raison."""
-  name: String!
-
-  """Entreprise associée."""
-  company: Company!
-
-  """Date de création."""
-  created_at: DateTime!
-
-  """Date de mise à jour."""
-  updated_at: DateTime!
-}
-
-"""Type représentant une unité de mesure"""
-type MeasurementUnitType {
-  """Valeur utilisée en interne (ex: 'kg', 'L')"""
-  value: String!
-
-  """Libellé français (ex: 'Kilogramme (kg)')"""
-  label: String!
-
-  """Catégorie de l'unité (masse, volume ou unité)"""
-  category: String!
-}
-
-type Menu {
-  id: ID!
-  name: String!
-  description: String
-  image_url: String
-  is_a_la_carte: Boolean!
-  service_type: MenuServiceTypeEnum!
-  is_returnable: Boolean!
-  available(quantity: Int! = 1): Boolean!
-  type: String!
-  menu_type_id: ID!
-  public_priority: Int!
-  menu_type: MenuType
-  price: Float!
-  categories: [MenuCategory!]!
-  allergens: [AllergenEnum!]!
-  items: [MenuItem!]!
-  created_at: DateTime!
-  updated_at: DateTime!
-}
-
-type MenuCategory {
-  """Unique primary key."""
-  id: ID!
-
-  """Category name."""
-  name: String!
-
-  """Menus in this category."""
-  menus: [Menu!]!
-
-  """The company that owns this category."""
-  company: Company!
-
-  """When the category was created."""
-  created_at: DateTime!
-
-  """When the category was last updated."""
-  updated_at: DateTime!
-}
-
-"""A paginated list of MenuCategory items."""
-type MenuCategoryPaginator {
-  """Pagination information about the list of items."""
-  paginatorInfo: PaginatorInfo!
-
-  """A list of MenuCategory items."""
-  data: [MenuCategory!]!
-}
-
-type MenuItem {
-  id: ID!
-  location: Location!
-  quantity: Float!
-  unit: UnitEnum!
-  entity: MenuItemEntity!
-}
-
-union MenuItemEntity = Ingredient | Preparation
-
-"""A paginated list of Menu items."""
-type MenuPaginator {
-  """Pagination information about the list of items."""
-  paginatorInfo: PaginatorInfo!
-
-  """A list of Menu items."""
-  data: [Menu!]!
-}
-
 enum MenuServiceTypeEnum {
   PREP
   DIRECT
-}
-
-type MenuType {
-  id: ID!
-  name: String!
-  public_index: Int!
-}
-
-"""Représente un produit alimentaire issu d'OpenFoodFacts"""
-type OpenFoodFactsProduct {
-  barcode: String
-  product_name: String
-  base_quantity: Float
-  unit: String
-  categories: [String]
-  imageUrl: String
-  is_already_in_database: Boolean
-  ingredient_id: ID
-}
-
-"""Représente une commande passée dans l'établissement."""
-type Order {
-  """Identifiant unique."""
-  id: ID!
-
-  """Table associée à la commande."""
-  table: Table!
-
-  """Entreprise propriétaire de la commande."""
-  company: Company!
-
-  """Utilisateur qui a créé la commande."""
-  user: User!
-
-  """Statut actuel de la commande."""
-  status: OrderStatusEnum!
-
-  """Horodatage du passage de la commande en statut PENDING."""
-  pending_at: DateTime
-
-  """Horodatage du service de la commande."""
-  served_at: DateTime
-
-  """Horodatage du paiement de la commande."""
-  payed_at: DateTime
-
-  """Horodatage de l'annulation éventuelle."""
-  canceled_at: DateTime
-
-  """
-  Prix total TTC calculé à partir des menus de toutes les étapes (prix × quantité).
-  """
-  price: Float!
-
-  """Étapes associées à la commande."""
-  steps: [OrderStep!]!
-
-  """Historique des actions liées à la commande (ordre chronologique)."""
-  histories: [OrderHistory!]!
-
-  """Date de création de la commande."""
-  created_at: DateTime!
-
-  """Date de dernière mise à jour."""
-  updated_at: DateTime!
-}
-
-"""Allows ordering a list of records."""
-input OrderByClause {
-  """The column that is used for ordering."""
-  column: String!
-
-  """The direction that is used for ordering."""
-  order: SortOrder!
-}
-
-"""
-Aggregate functions when ordering by a relation without specifying a column.
-"""
-enum OrderByRelationAggregateFunction {
-  """Amount of items."""
-  COUNT
-}
-
-"""
-Aggregate functions when ordering by a relation that may specify a column.
-"""
-enum OrderByRelationWithColumnAggregateFunction {
-  """Average."""
-  AVG
-
-  """Minimum."""
-  MIN
-
-  """Maximum."""
-  MAX
-
-  """Sum."""
-  SUM
-
-  """Amount of items."""
-  COUNT
-}
-
-"""Historique des actions effectuées sur une commande."""
-type OrderHistory {
-  """Identifiant unique de l'entrée."""
-  id: ID!
-
-  """Commande associée à l'entrée."""
-  order: Order!
-
-  """Étape concernée, le cas échéant."""
-  order_step: OrderStep
-
-  """Menu d'étape concerné, le cas échéant."""
-  step_menu: StepMenu
-
-  """Entreprise liée à l'entrée."""
-  company: Company!
-
-  """Utilisateur ayant réalisé l'action."""
-  user: User
-
-  """Type d'action enregistrée."""
-  action: OrderHistoryActionEnum!
-
-  """Informations métier associées à l'action."""
-  payload: JSON
-
-  """Raison associée à l'action (si applicable)."""
-  reason: String
-
-  """Date de création de l'entrée."""
-  created_at: DateTime!
-
-  """Date de dernière mise à jour."""
-  updated_at: DateTime!
-}
-
-"""Liste des actions possibles sur l'historique des commandes."""
-enum OrderHistoryActionEnum {
-  ORDER_CREATED
-  ORDER_STATUS_UPDATED
-  ORDER_STEP_CREATED
-  ORDER_STEP_STATUS_UPDATED
-  STEP_MENU_ADDED
-  STEP_MENU_UPDATED
-  STEP_MENU_REMOVED
-  STEP_MENU_STATUS_UPDATED
-}
-
-"""Options de tri disponibles pour les commandes."""
-input OrderOrderByClause {
-  """Colonne utilisée pour le tri."""
-  column: OrderOrderByField!
-
-  """Direction du tri."""
-  order: SortOrder! = ASC
-}
-
-"""Colonnes triables pour les commandes."""
-enum OrderOrderByField {
-  ID
-  STATUS
-  TABLE_ID
-  USER_ID
-  PENDING_AT
-  SERVED_AT
-  PAYED_AT
-  CANCELED_AT
-  CREATED_AT
-  UPDATED_AT
-}
-
-"""A paginated list of Order items."""
-type OrderPaginator {
-  """Pagination information about the list of items."""
-  paginatorInfo: PaginatorInfo!
-
-  """A list of Order items."""
-  data: [Order!]!
-}
-
-"""Statistiques agrégées sur les commandes."""
-type OrdersStats {
-  pending: Int!
-  served: Int!
-  payed: Int!
-  canceled: Int!
-  total: Int!
-  revenue: Float!
 }
 
 enum OrderStatusEnum {
@@ -700,232 +45,16 @@ enum OrderStatusEnum {
   CANCELED
 }
 
-"""Étape individuelle d'une commande."""
-type OrderStep {
-  """Identifiant unique."""
-  id: ID!
-
-  """Commande à laquelle appartient l'étape."""
-  order: Order!
-
-  """Position de l'étape dans le flux de service."""
-  position: Int!
-
-  """Statut actuel de l'étape."""
-  status: OrderStepStatusEnum!
-
-  """Horodatage du service de l'étape."""
-  served_at: DateTime
-
-  """
-  Prix TTC de l'étape calculé en sommant prix × quantité des menus associés.
-  """
-  price: Float!
-
-  """Menus associés à cette étape."""
-  stepMenus: [StepMenu!]!
-
-  """Menus liés via la relation pivot."""
-  menus: [Menu!]!
-
-  """Date de création de l'étape."""
-  created_at: DateTime!
-
-  """Date de dernière mise à jour."""
-  updated_at: DateTime!
-}
-
-"""Options de tri disponibles pour les étapes de commande."""
-input OrderStepOrderByClause {
-  """Colonne utilisée pour le tri."""
-  column: OrderStepOrderByField!
-
-  """Direction du tri."""
-  order: SortOrder! = ASC
-}
-
-"""Colonnes triables pour les étapes de commande."""
-enum OrderStepOrderByField {
-  ID
-  ORDER_ID
-  POSITION
-  STATUS
-  SERVED_AT
-  CREATED_AT
-  UPDATED_AT
-}
-
-"""A paginated list of OrderStep items."""
-type OrderStepPaginator {
-  """Pagination information about the list of items."""
-  paginatorInfo: PaginatorInfo!
-
-  """A list of OrderStep items."""
-  data: [OrderStep!]!
-}
-
 enum OrderStepStatusEnum {
   IN_PREP
   READY
   SERVED
 }
 
-"""Information about pagination using a fully featured paginator."""
-type PaginatorInfo {
-  """Number of items in the current page."""
-  count: Int!
-
-  """Index of the current page."""
-  currentPage: Int!
-
-  """Index of the first item in the current page."""
-  firstItem: Int
-
-  """Are there more pages after this one?"""
-  hasMorePages: Boolean!
-
-  """Index of the last item in the current page."""
-  lastItem: Int
-
-  """Index of the last available page."""
-  lastPage: Int!
-
-  """Number of items per page."""
-  perPage: Int!
-
-  """Number of total available items."""
-  total: Int!
-}
-
-type Perishable {
-  id: ID!
-  ingredient: Ingredient!
-  location: Location!
-  quantity: Float!
-  is_read: Boolean!
-  expiration_at: DateTime!
-  created_at: DateTime!
-  updated_at: DateTime!
-}
-
-enum PerishableFilter {
-  FRESH
-  SOON
-  EXPIRED
-}
-
-type Preparation {
-  """Unique primary key."""
-  id: ID!
-
-  """Preparation name."""
-  name: String!
-
-  """Unit of measurement for the preparation."""
-  unit: UnitEnum!
-
-  """Quantity for one unit of the preparation."""
-  base_quantity: Float!
-
-  """Unit for the base quantity of the preparation."""
-  base_unit: UnitEnum!
-
-  """Allergens contained in this preparation."""
-  allergens: [AllergenEnum!]!
-
-  """The company that produces this preparation."""
-  company: Company!
-
-  """Threshold below which the preparation is considered understocked."""
-  threshold: Float
-  entities: [PreparationEntity!]!
-  locations: [Location!]!
-
-  """The categories associated with this preparation."""
-  categories: [Category!]!
-  quantities: [PreparationQuantity!]!
-  preparable_quantity: PreparationPreparableQuantity!
-  image_url: String
-
-  """Historique des mouvements de stock pour cette préparation"""
-  stockMovements: [StockMovement!]!
-  withdrawals_today_count: Int!
-
-  """Number of withdrawals for this ingredient today."""
-  withdrawals_this_week_count: Int!
-
-  """Number of withdrawals for this ingredient this week."""
-  withdrawals_this_month_count: Int!
-
-  """When the preparation was created."""
-  created_at: DateTime!
-
-  """When the preparation was last updated."""
-  updated_at: DateTime!
-}
-
-type PreparationEntity {
-  id: ID!
-  entity: PreparationEntityItem!
-  preparation: Preparation!
-  location: Location!
-  quantity: Float!
-  unit: UnitEnum!
-}
-
-union PreparationEntityItem = Ingredient | Preparation
-
-input PreparationOrderByClause {
-  column: PreparationOrderByField!
-  order: SortOrder! = ASC
-}
-
-enum PreparationOrderByField {
-  ID
-  NAME
-  CREATED_AT
-  UPDATED_AT
-  WITHDRAWALS_TODAY
-  WITHDRAWALS_THIS_WEEK
-  WITHDRAWALS_THIS_MONTH
-}
-
-"""A paginated list of Preparation items."""
-type PreparationPaginator {
-  """Pagination information about the list of items."""
-  paginatorInfo: PaginatorInfo!
-
-  """A list of Preparation items."""
-  data: [Preparation!]!
-}
-
-type PreparationPreparableQuantity {
-  """Quantité maximale préparable avec le stock actuel."""
-  quantity: Float!
-
-  """Unité associée à la préparation."""
-  unit: UnitEnum!
-}
-
-type PreparationQuantity {
-  """Le stock de la préparation."""
-  quantity: Float!
-
-  """La localisation de ce stock."""
-  location: Location!
-}
-
-type PublicMenuSettings {
-  """Identifiant public unique pour partager la carte du restaurant."""
-  public_menu_card_url: String!
-
-  """
-  Affiche aussi les menus qui n'ont pas assez de stock sur la carte publique.
-  """
-  show_out_of_stock_menus_on_card: Boolean!
-
-  """Affiche les images des menus sur la carte publique."""
-  show_menu_images: Boolean!
+enum StepMenuStatusEnum {
+  IN_PREP
+  READY
+  SERVED
 }
 
 type Query {
@@ -1366,50 +495,734 @@ type Query {
   ): UserPaginator!
 }
 
-"""Order by clause for Query.orders.orderBy."""
-input QueryOrdersOrderByOrderByClause {
-  """The column that is used for ordering."""
+"""
+A datetime string with format `Y-m-d H:i:s`, e.g. `2018-05-23 13:43:32`.
+"""
+scalar DateTime
+
+scalar Date
+
+scalar JSON
+
+"""Directions for ordering a list of records."""
+enum SortOrder {
+  """Sort records in ascending order."""
+  ASC
+
+  """Sort records in descending order."""
+  DESC
+}
+
+type Category {
+  """Unique primary key."""
+  id: ID!
+
+  """Category name."""
+  name: String!
+
+  """Ingredients in this category."""
+  ingredients: [Ingredient!]!
+
+  """Preparations in this category."""
+  preparations: [Preparation!]!
+
+  """The company that owns this category."""
+  company: Company!
+
+  """Shelf life durations by location type."""
+  shelfLives: [CategoryShelfLife!]!
+
+  """When the Category was created."""
+  created_at: DateTime!
+
+  """When the Category was last updated."""
+  updated_at: DateTime!
+}
+
+type CategoryShelfLife {
+  """The location type for this shelf life."""
+  locationType: LocationType!
+
+  """Shelf life in hours for the category at this location type."""
+  shelf_life_hours: Int!
+}
+
+type Company {
+  """Unique primary key."""
+  id: ID!
+
+  """Company name."""
+  name: String!
+
+  """Preparations associated with this company."""
+  preparations: [Preparation!]!
+  categories: [Category!]!
+  locations: [Location!]!
+
+  """Types de localisation associés à cette entreprise."""
+  locationTypes: [LocationType!]!
+
+  """Langue préférée pour les données OpenFoodFacts (fr ou en)."""
+  open_food_facts_language: String
+
+  """Paramètres visibles publiquement pour la carte des menus."""
+  public_menu_settings: PublicMenuSettings!
+
+  """Logo ou image de présentation de l'entreprise."""
+  logo_path: String
+
+  """Nom de la personne à contacter."""
+  contact_name: String
+
+  """Adresse e-mail de contact."""
+  contact_email: String
+
+  """Numéro de téléphone principal."""
+  contact_phone: String
+
+  """Ligne d'adresse principale."""
+  address_line: String
+
+  """Code postal."""
+  postal_code: String
+
+  """Ville."""
+  city: String
+
+  """Pays."""
+  country: String
+
+  """Horaires d'ouverture de la semaine."""
+  businessHours: [CompanyBusinessHour!]!
+
+  """When the company was created."""
+  created_at: DateTime!
+
+  """When the company was last updated."""
+  updated_at: DateTime!
+}
+
+type CompanyBusinessHour {
+  id: ID!
+  day_of_week: Int!
+  opens_at: String!
+  closes_at: String!
+  is_overnight: Boolean!
+  sequence: Int!
+  created_at: DateTime!
+  updated_at: DateTime!
+}
+
+"""Options de tri pour les entreprises."""
+input CompanyOrderByOrderByClause {
+  """Champ sur lequel effectuer le tri."""
+  field: CompanyOrderByField!
+
+  """Direction du tri."""
+  order: SortOrder!
+}
+
+"""Champs disponibles pour le tri des entreprises."""
+enum CompanyOrderByField {
+  ID
+  NAME
+  CREATED_AT
+  UPDATED_AT
+}
+
+type PublicMenuSettings {
+  """Identifiant public unique pour partager la carte du restaurant."""
+  public_menu_card_url: String!
+
+  """
+  Affiche aussi les menus qui n'ont pas assez de stock sur la carte publique.
+  """
+  show_out_of_stock_menus_on_card: Boolean!
+
+  """Affiche les images des menus sur la carte publique."""
+  show_menu_images: Boolean!
+}
+
+type Ingredient {
+  """Unique primary key."""
+  id: ID!
+
+  """Ingredient name."""
+  name: String!
+
+  """Unit of measurement for the ingredient."""
+  unit: UnitEnum!
+
+  """Quantity for one unit of the ingredient."""
+  base_quantity: Float!
+
+  """Unit for the base quantity of the ingredient."""
+  base_unit: UnitEnum!
+
+  """Optional minimum stock quantity before alerting."""
+  threshold: Float
+
+  """Allergens contained in the ingredient."""
+  allergens: [AllergenEnum!]!
+  quantities: [IngredientQuantity!]!
+
+  """The company that owns this ingredient."""
+  company: Company!
+  category: Category!
+  image_url: String
+
+  """Historique des mouvements de stock pour cet ingrédient"""
+  stockMovements(orderBy: [StockMovementOrderByClause!]): [StockMovement!]!
+  withdrawals_today_count: Int!
+
+  """Number of withdrawals for this ingredient today."""
+  withdrawals_this_week_count: Int!
+
+  """Number of withdrawals for this ingredient this week."""
+  withdrawals_this_month_count: Int!
+
+  """When the ingredient was created."""
+  created_at: DateTime!
+
+  """When the ingredient was last updated."""
+  updated_at: DateTime!
+}
+
+enum IngredientOrderByField {
+  ID
+  NAME
+  CREATED_AT
+  UPDATED_AT
+  WITHDRAWALS_TODAY
+  WITHDRAWALS_THIS_WEEK
+  WITHDRAWALS_THIS_MONTH
+}
+
+input IngredientOrderByClause {
+  column: IngredientOrderByField!
+  order: SortOrder! = ASC
+}
+
+type IngredientQuantity {
+  """Le stock de l'ingrédient."""
+  quantity: Float!
+
+  """La localisation de ce stock."""
+  location: Location!
+}
+
+type Location {
+  """Unique primary key."""
+  id: ID!
+
+  """Location name."""
+  name: String!
+
+  """Location company."""
+  company: Company!
+
+  """Type de localisation (Congélateur, Réfrigérateur, etc.)"""
+  locationType: LocationType
+
+  """When the location was created."""
+  created_at: DateTime!
+
+  """When the location was last updated."""
+  updated_at: DateTime!
+
+  """Ingredients stored in this location."""
+  ingredients: [Ingredient!]!
+}
+
+"""Options de tri pour les emplacements."""
+input LocationOrderByOrderByClause {
+  """Champ sur lequel effectuer le tri."""
+  field: LocationOrderByField!
+
+  """Direction du tri."""
+  order: SortOrder!
+}
+
+"""Champs disponibles pour le tri des emplacements."""
+enum LocationOrderByField {
+  ID
+  NAME
+  CREATED_AT
+  UPDATED_AT
+}
+
+"""Type de localisation pour organiser les emplacements de stockage"""
+type LocationType {
+  """Identifiant unique."""
+  id: ID!
+
+  """Nom du type de localisation."""
+  name: String!
+
+  """Indique si c'est un type par défaut (non modifiable)."""
+  is_default: Boolean!
+
+  """L'entreprise à laquelle appartient ce type."""
+  company: Company!
+
+  """Emplacements utilisant ce type de localisation."""
+  locations: [Location!]!
+
+  """Date de création du type."""
+  created_at: DateTime!
+
+  """Date de dernière mise à jour du type."""
+  updated_at: DateTime!
+}
+
+"""Options de tri pour les types de localisation."""
+input LocationTypeOrderByOrderByClause {
+  """Champ sur lequel effectuer le tri."""
+  field: LocationTypeOrderByField!
+
+  """Direction du tri."""
+  order: SortOrder!
+}
+
+"""Champs disponibles pour le tri des types de localisation."""
+enum LocationTypeOrderByField {
+  ID
+  NAME
+  IS_DEFAULT
+  CREATED_AT
+  UPDATED_AT
+}
+
+"""Représente une perte d'ingrédient ou de préparation."""
+type Loss {
+  """Identifiant unique."""
+  id: ID!
+
+  """Type d'entité concernée par cette perte (ingredient ou preparation)."""
+  loss_item_type: String!
+
+  """ID de l'entité concernée."""
+  loss_item_id: ID!
+
+  """L'emplacement où la perte a eu lieu."""
+  location: Location!
+
+  """L'entreprise à laquelle appartient cette perte."""
+  company: Company!
+
+  """L'utilisateur qui a enregistré la perte."""
+  user: User
+
+  """Quantité perdue."""
+  quantity: Float!
+
+  """Raison de la perte."""
+  reason: String!
+
+  """Date et heure de création de la perte."""
+  created_at: DateTime!
+
+  """Date et heure de dernière mise à jour de la perte."""
+  updated_at: DateTime!
+}
+
+"""Statistiques des pertes par type."""
+type LossesStats {
+  ingredient: Float!
+  preparation: Float!
+  total: Float!
+}
+
+input LossOrderByClause {
+  field: LossOrderByField!
+  order: SortOrder!
+}
+
+enum LossOrderByField {
+  ID
+  QUANTITY
+  CREATED_AT
+  UPDATED_AT
+}
+
+"""Raison de perte prédéfinie pour une entreprise."""
+type LossReason {
+  """Identifiant unique."""
+  id: ID!
+
+  """Nom de la raison."""
+  name: String!
+
+  """Entreprise associée."""
+  company: Company!
+
+  """Date de création."""
+  created_at: DateTime!
+
+  """Date de mise à jour."""
+  updated_at: DateTime!
+}
+
+"""Type représentant une unité de mesure"""
+type MeasurementUnitType {
+  """Valeur utilisée en interne (ex: 'kg', 'L')"""
+  value: String!
+
+  """Libellé français (ex: 'Kilogramme (kg)')"""
+  label: String!
+
+  """Catégorie de l'unité (masse, volume ou unité)"""
+  category: String!
+}
+
+type Menu {
+  id: ID!
+  name: String!
+  description: String
+  image_url: String
+  is_a_la_carte: Boolean!
+  service_type: MenuServiceTypeEnum!
+  is_returnable: Boolean!
+  available(quantity: Int! = 1): Boolean!
+  type: String!
+  menu_type_id: ID!
+  public_priority: Int!
+  menu_type: MenuType
+  price: Float!
+  categories: [MenuCategory!]!
+  allergens: [AllergenEnum!]!
+  items: [MenuItem!]!
+  created_at: DateTime!
+  updated_at: DateTime!
+}
+
+type MenuType {
+  id: ID!
+  name: String!
+  public_index: Int!
+}
+
+type MenuItem {
+  id: ID!
+  location: Location!
+  quantity: Float!
+  unit: UnitEnum!
+  entity: MenuItemEntity!
+}
+
+union MenuItemEntity = Ingredient | Preparation
+
+type MenuCategory {
+  """Unique primary key."""
+  id: ID!
+
+  """Category name."""
+  name: String!
+
+  """Menus in this category."""
+  menus: [Menu!]!
+
+  """The company that owns this category."""
+  company: Company!
+
+  """When the category was created."""
+  created_at: DateTime!
+
+  """When the category was last updated."""
+  updated_at: DateTime!
+}
+
+"""Représente une commande passée dans l'établissement."""
+type Order {
+  """Identifiant unique."""
+  id: ID!
+
+  """Table associée à la commande."""
+  table: Table!
+
+  """Entreprise propriétaire de la commande."""
+  company: Company!
+
+  """Utilisateur qui a créé la commande."""
+  user: User!
+
+  """Statut actuel de la commande."""
+  status: OrderStatusEnum!
+
+  """Horodatage du passage de la commande en statut PENDING."""
+  pending_at: DateTime
+
+  """Horodatage du service de la commande."""
+  served_at: DateTime
+
+  """Horodatage du paiement de la commande."""
+  payed_at: DateTime
+
+  """Horodatage de l'annulation éventuelle."""
+  canceled_at: DateTime
+
+  """
+  Prix total TTC calculé à partir des menus de toutes les étapes (prix × quantité).
+  """
+  price: Float!
+
+  """Étapes associées à la commande."""
+  steps: [OrderStep!]!
+
+  """Historique des actions liées à la commande (ordre chronologique)."""
+  histories: [OrderHistory!]!
+
+  """Date de création de la commande."""
+  created_at: DateTime!
+
+  """Date de dernière mise à jour."""
+  updated_at: DateTime!
+}
+
+"""Statistiques agrégées sur les commandes."""
+type OrdersStats {
+  pending: Int!
+  served: Int!
+  payed: Int!
+  canceled: Int!
+  total: Int!
+  revenue: Float!
+}
+
+"""Options de tri disponibles pour les commandes."""
+input OrderOrderByClause {
+  """Colonne utilisée pour le tri."""
   column: OrderOrderByField!
 
-  """The direction that is used for ordering."""
-  order: SortOrder!
+  """Direction du tri."""
+  order: SortOrder! = ASC
 }
 
-"""Order by clause for Query.orderSteps.orderBy."""
-input QueryOrderStepsOrderByOrderByClause {
-  """The column that is used for ordering."""
+"""Colonnes triables pour les commandes."""
+enum OrderOrderByField {
+  ID
+  STATUS
+  TABLE_ID
+  USER_ID
+  PENDING_AT
+  SERVED_AT
+  PAYED_AT
+  CANCELED_AT
+  CREATED_AT
+  UPDATED_AT
+}
+
+"""Historique des actions effectuées sur une commande."""
+type OrderHistory {
+  """Identifiant unique de l'entrée."""
+  id: ID!
+
+  """Commande associée à l'entrée."""
+  order: Order!
+
+  """Étape concernée, le cas échéant."""
+  order_step: OrderStep
+
+  """Menu d'étape concerné, le cas échéant."""
+  step_menu: StepMenu
+
+  """Entreprise liée à l'entrée."""
+  company: Company!
+
+  """Utilisateur ayant réalisé l'action."""
+  user: User
+
+  """Type d'action enregistrée."""
+  action: OrderHistoryActionEnum!
+
+  """Informations métier associées à l'action."""
+  payload: JSON
+
+  """Raison associée à l'action (si applicable)."""
+  reason: String
+
+  """Date de création de l'entrée."""
+  created_at: DateTime!
+
+  """Date de dernière mise à jour."""
+  updated_at: DateTime!
+}
+
+"""Liste des actions possibles sur l'historique des commandes."""
+enum OrderHistoryActionEnum {
+  ORDER_CREATED
+  ORDER_STATUS_UPDATED
+  ORDER_STEP_CREATED
+  ORDER_STEP_STATUS_UPDATED
+  STEP_MENU_ADDED
+  STEP_MENU_UPDATED
+  STEP_MENU_REMOVED
+  STEP_MENU_STATUS_UPDATED
+}
+
+"""Étape individuelle d'une commande."""
+type OrderStep {
+  """Identifiant unique."""
+  id: ID!
+
+  """Commande à laquelle appartient l'étape."""
+  order: Order!
+
+  """Position de l'étape dans le flux de service."""
+  position: Int!
+
+  """Statut actuel de l'étape."""
+  status: OrderStepStatusEnum!
+
+  """Horodatage du service de l'étape."""
+  served_at: DateTime
+
+  """
+  Prix TTC de l'étape calculé en sommant prix × quantité des menus associés.
+  """
+  price: Float!
+
+  """Menus associés à cette étape."""
+  stepMenus: [StepMenu!]!
+
+  """Menus liés via la relation pivot."""
+  menus: [Menu!]!
+
+  """Date de création de l'étape."""
+  created_at: DateTime!
+
+  """Date de dernière mise à jour."""
+  updated_at: DateTime!
+}
+
+"""Options de tri disponibles pour les étapes de commande."""
+input OrderStepOrderByClause {
+  """Colonne utilisée pour le tri."""
   column: OrderStepOrderByField!
 
-  """The direction that is used for ordering."""
-  order: SortOrder!
+  """Direction du tri."""
+  order: SortOrder! = ASC
 }
 
-"""Order by clause for Query.rooms.orderBy."""
-input QueryRoomsOrderByOrderByClause {
-  """The column that is used for ordering."""
-  column: RoomOrderByField!
-
-  """The direction that is used for ordering."""
-  order: SortOrder!
+"""Colonnes triables pour les étapes de commande."""
+enum OrderStepOrderByField {
+  ID
+  ORDER_ID
+  POSITION
+  STATUS
+  SERVED_AT
+  CREATED_AT
+  UPDATED_AT
 }
 
-"""Order by clause for Query.stepMenus.orderBy."""
-input QueryStepMenusOrderByOrderByClause {
-  """The column that is used for ordering."""
-  column: StepMenuOrderByField!
-
-  """The direction that is used for ordering."""
-  order: SortOrder!
+enum PerishableFilter {
+  FRESH
+  SOON
+  EXPIRED
 }
 
-"""Order by clause for Query.tables.orderBy."""
-input QueryTablesOrderByOrderByClause {
-  """The column that is used for ordering."""
-  column: TableOrderByField!
-
-  """The direction that is used for ordering."""
-  order: SortOrder!
+type Perishable {
+  id: ID!
+  ingredient: Ingredient!
+  location: Location!
+  quantity: Float!
+  is_read: Boolean!
+  expiration_at: DateTime!
+  created_at: DateTime!
+  updated_at: DateTime!
 }
+
+type Preparation {
+  """Unique primary key."""
+  id: ID!
+
+  """Preparation name."""
+  name: String!
+
+  """Unit of measurement for the preparation."""
+  unit: UnitEnum!
+
+  """Quantity for one unit of the preparation."""
+  base_quantity: Float!
+
+  """Unit for the base quantity of the preparation."""
+  base_unit: UnitEnum!
+
+  """Allergens contained in this preparation."""
+  allergens: [AllergenEnum!]!
+
+  """The company that produces this preparation."""
+  company: Company!
+
+  """Threshold below which the preparation is considered understocked."""
+  threshold: Float
+  entities: [PreparationEntity!]!
+  locations: [Location!]!
+
+  """The categories associated with this preparation."""
+  categories: [Category!]!
+  quantities: [PreparationQuantity!]!
+  preparable_quantity: PreparationPreparableQuantity!
+  image_url: String
+
+  """Historique des mouvements de stock pour cette préparation"""
+  stockMovements: [StockMovement!]!
+  withdrawals_today_count: Int!
+
+  """Number of withdrawals for this ingredient today."""
+  withdrawals_this_week_count: Int!
+
+  """Number of withdrawals for this ingredient this week."""
+  withdrawals_this_month_count: Int!
+
+  """When the preparation was created."""
+  created_at: DateTime!
+
+  """When the preparation was last updated."""
+  updated_at: DateTime!
+}
+
+type PreparationQuantity {
+  """Le stock de la préparation."""
+  quantity: Float!
+
+  """La localisation de ce stock."""
+  location: Location!
+}
+
+type PreparationPreparableQuantity {
+  """Quantité maximale préparable avec le stock actuel."""
+  quantity: Float!
+
+  """Unité associée à la préparation."""
+  unit: UnitEnum!
+}
+
+enum PreparationOrderByField {
+  ID
+  NAME
+  CREATED_AT
+  UPDATED_AT
+  WITHDRAWALS_TODAY
+  WITHDRAWALS_THIS_WEEK
+  WITHDRAWALS_THIS_MONTH
+}
+
+input PreparationOrderByClause {
+  column: PreparationOrderByField!
+  order: SortOrder! = ASC
+}
+
+type PreparationEntity {
+  id: ID!
+  entity: PreparationEntityItem!
+  preparation: Preparation!
+  location: Location!
+  quantity: Float!
+  unit: UnitEnum!
+}
+
+union PreparationEntityItem = Ingredient | Preparation
 
 """Bouton d’accès rapide configurable pour une entreprise."""
 type QuickAccess {
@@ -1460,25 +1273,19 @@ enum RoomOrderByField {
   UPDATED_AT
 }
 
-"""A paginated list of Room items."""
-type RoomPaginator {
-  """Pagination information about the list of items."""
-  paginatorInfo: PaginatorInfo!
-
-  """A list of Room items."""
-  data: [Room!]!
+"""Représente un produit alimentaire issu d'OpenFoodFacts"""
+type OpenFoodFactsProduct {
+  barcode: String
+  product_name: String
+  base_quantity: Float
+  unit: String
+  categories: [String]
+  imageUrl: String
+  is_already_in_database: Boolean
+  ingredient_id: ID
 }
 
 union SearchResult = Ingredient | Preparation
-
-"""Directions for ordering a list of records."""
-enum SortOrder {
-  """Sort records in ascending order."""
-  ASC
-
-  """Sort records in descending order."""
-  DESC
-}
 
 """Association entre une étape de commande et un menu."""
 type StepMenu {
@@ -1529,21 +1336,6 @@ enum StepMenuOrderByField {
   SERVED_AT
   CREATED_AT
   UPDATED_AT
-}
-
-"""A paginated list of StepMenu items."""
-type StepMenuPaginator {
-  """Pagination information about the list of items."""
-  paginatorInfo: PaginatorInfo!
-
-  """A list of StepMenu items."""
-  data: [StepMenu!]!
-}
-
-enum StepMenuStatusEnum {
-  IN_PREP
-  READY
-  SERVED
 }
 
 """Représente un mouvement de stock d'un ingrédient ou d'une préparation."""
@@ -1608,15 +1400,6 @@ enum StockMovementOrderByField {
   UPDATED_AT
 }
 
-"""A paginated list of StockMovement items."""
-type StockMovementPaginator {
-  """Pagination information about the list of items."""
-  paginatorInfo: PaginatorInfo!
-
-  """A list of StockMovement items."""
-  data: [StockMovement!]!
-}
-
 type Table {
   """Unique primary key."""
   id: ID!
@@ -1635,47 +1418,6 @@ enum TableOrderByField {
   ROOM_ID
   CREATED_AT
   UPDATED_AT
-}
-
-"""A paginated list of Table items."""
-type TablePaginator {
-  """Pagination information about the list of items."""
-  paginatorInfo: PaginatorInfo!
-
-  """A list of Table items."""
-  data: [Table!]!
-}
-
-"""
-Specify if you want to include or exclude trashed results from a query.
-"""
-enum Trashed {
-  """Only return trashed results."""
-  ONLY
-
-  """Return both trashed and non-trashed results."""
-  WITH
-
-  """Only return non-trashed results."""
-  WITHOUT
-}
-
-enum UnitEnum {
-  kg
-  hg
-  dag
-  g
-  dg
-  cg
-  mg
-  kL
-  hL
-  daL
-  L
-  dL
-  cL
-  mL
-  unit
 }
 
 """Account of a person who uses this application."""
@@ -1702,6 +1444,168 @@ type User {
   updated_at: DateTime!
 }
 
+"""Information about pagination using a fully featured paginator."""
+type PaginatorInfo {
+  """Number of items in the current page."""
+  count: Int!
+
+  """Index of the current page."""
+  currentPage: Int!
+
+  """Index of the first item in the current page."""
+  firstItem: Int
+
+  """Are there more pages after this one?"""
+  hasMorePages: Boolean!
+
+  """Index of the last item in the current page."""
+  lastItem: Int
+
+  """Index of the last available page."""
+  lastPage: Int!
+
+  """Number of items per page."""
+  perPage: Int!
+
+  """Number of total available items."""
+  total: Int!
+}
+
+"""A paginated list of Category items."""
+type CategoryPaginator {
+  """Pagination information about the list of items."""
+  paginatorInfo: PaginatorInfo!
+
+  """A list of Category items."""
+  data: [Category!]!
+}
+
+"""A paginated list of Company items."""
+type CompanyPaginator {
+  """Pagination information about the list of items."""
+  paginatorInfo: PaginatorInfo!
+
+  """A list of Company items."""
+  data: [Company!]!
+}
+
+"""A paginated list of Ingredient items."""
+type IngredientPaginator {
+  """Pagination information about the list of items."""
+  paginatorInfo: PaginatorInfo!
+
+  """A list of Ingredient items."""
+  data: [Ingredient!]!
+}
+
+"""A paginated list of Location items."""
+type LocationPaginator {
+  """Pagination information about the list of items."""
+  paginatorInfo: PaginatorInfo!
+
+  """A list of Location items."""
+  data: [Location!]!
+}
+
+"""A paginated list of LocationType items."""
+type LocationTypePaginator {
+  """Pagination information about the list of items."""
+  paginatorInfo: PaginatorInfo!
+
+  """A list of LocationType items."""
+  data: [LocationType!]!
+}
+
+"""A paginated list of Loss items."""
+type LossPaginator {
+  """Pagination information about the list of items."""
+  paginatorInfo: PaginatorInfo!
+
+  """A list of Loss items."""
+  data: [Loss!]!
+}
+
+"""A paginated list of Menu items."""
+type MenuPaginator {
+  """Pagination information about the list of items."""
+  paginatorInfo: PaginatorInfo!
+
+  """A list of Menu items."""
+  data: [Menu!]!
+}
+
+"""A paginated list of MenuCategory items."""
+type MenuCategoryPaginator {
+  """Pagination information about the list of items."""
+  paginatorInfo: PaginatorInfo!
+
+  """A list of MenuCategory items."""
+  data: [MenuCategory!]!
+}
+
+"""A paginated list of Order items."""
+type OrderPaginator {
+  """Pagination information about the list of items."""
+  paginatorInfo: PaginatorInfo!
+
+  """A list of Order items."""
+  data: [Order!]!
+}
+
+"""A paginated list of OrderStep items."""
+type OrderStepPaginator {
+  """Pagination information about the list of items."""
+  paginatorInfo: PaginatorInfo!
+
+  """A list of OrderStep items."""
+  data: [OrderStep!]!
+}
+
+"""A paginated list of Preparation items."""
+type PreparationPaginator {
+  """Pagination information about the list of items."""
+  paginatorInfo: PaginatorInfo!
+
+  """A list of Preparation items."""
+  data: [Preparation!]!
+}
+
+"""A paginated list of Room items."""
+type RoomPaginator {
+  """Pagination information about the list of items."""
+  paginatorInfo: PaginatorInfo!
+
+  """A list of Room items."""
+  data: [Room!]!
+}
+
+"""A paginated list of StepMenu items."""
+type StepMenuPaginator {
+  """Pagination information about the list of items."""
+  paginatorInfo: PaginatorInfo!
+
+  """A list of StepMenu items."""
+  data: [StepMenu!]!
+}
+
+"""A paginated list of StockMovement items."""
+type StockMovementPaginator {
+  """Pagination information about the list of items."""
+  paginatorInfo: PaginatorInfo!
+
+  """A list of StockMovement items."""
+  data: [StockMovement!]!
+}
+
+"""A paginated list of Table items."""
+type TablePaginator {
+  """Pagination information about the list of items."""
+  paginatorInfo: PaginatorInfo!
+
+  """A list of Table items."""
+  data: [Table!]!
+}
+
 """A paginated list of User items."""
 type UserPaginator {
   """Pagination information about the list of items."""
@@ -1711,3 +1615,98 @@ type UserPaginator {
   data: [User!]!
 }
 
+"""Order by clause for Query.orders.orderBy."""
+input QueryOrdersOrderByOrderByClause {
+  """The column that is used for ordering."""
+  column: OrderOrderByField!
+
+  """The direction that is used for ordering."""
+  order: SortOrder!
+}
+
+"""Order by clause for Query.orderSteps.orderBy."""
+input QueryOrderStepsOrderByOrderByClause {
+  """The column that is used for ordering."""
+  column: OrderStepOrderByField!
+
+  """The direction that is used for ordering."""
+  order: SortOrder!
+}
+
+"""Order by clause for Query.rooms.orderBy."""
+input QueryRoomsOrderByOrderByClause {
+  """The column that is used for ordering."""
+  column: RoomOrderByField!
+
+  """The direction that is used for ordering."""
+  order: SortOrder!
+}
+
+"""Order by clause for Query.stepMenus.orderBy."""
+input QueryStepMenusOrderByOrderByClause {
+  """The column that is used for ordering."""
+  column: StepMenuOrderByField!
+
+  """The direction that is used for ordering."""
+  order: SortOrder!
+}
+
+"""Order by clause for Query.tables.orderBy."""
+input QueryTablesOrderByOrderByClause {
+  """The column that is used for ordering."""
+  column: TableOrderByField!
+
+  """The direction that is used for ordering."""
+  order: SortOrder!
+}
+
+"""
+Aggregate functions when ordering by a relation without specifying a column.
+"""
+enum OrderByRelationAggregateFunction {
+  """Amount of items."""
+  COUNT
+}
+
+"""
+Aggregate functions when ordering by a relation that may specify a column.
+"""
+enum OrderByRelationWithColumnAggregateFunction {
+  """Average."""
+  AVG
+
+  """Minimum."""
+  MIN
+
+  """Maximum."""
+  MAX
+
+  """Sum."""
+  SUM
+
+  """Amount of items."""
+  COUNT
+}
+
+"""Allows ordering a list of records."""
+input OrderByClause {
+  """The column that is used for ordering."""
+  column: String!
+
+  """The direction that is used for ordering."""
+  order: SortOrder!
+}
+
+"""
+Specify if you want to include or exclude trashed results from a query.
+"""
+enum Trashed {
+  """Only return trashed results."""
+  ONLY
+
+  """Return both trashed and non-trashed results."""
+  WITH
+
+  """Only return non-trashed results."""
+  WITHOUT
+}

--- a/packages/graphql/src/schema/schema.graphql.d.ts
+++ b/packages/graphql/src/schema/schema.graphql.d.ts
@@ -14,11 +14,29 @@ export type Scalars = {
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }
   Float: { input: number; output: number; }
-  Date: { input: string; output: string; }
   /** A datetime string with format `Y-m-d H:i:s`, e.g. `2018-05-23 13:43:32`. */
   DateTime: { input: string; output: string; }
+  Date: { input: string; output: string; }
   JSON: { input: unknown; output: unknown; }
 };
+
+export enum UnitEnum {
+  Kg = 'kg',
+  Hg = 'hg',
+  Dag = 'dag',
+  G = 'g',
+  Dg = 'dg',
+  Cg = 'cg',
+  Mg = 'mg',
+  KL = 'kL',
+  HL = 'hL',
+  DaL = 'daL',
+  L = 'L',
+  DL = 'dL',
+  CL = 'cL',
+  ML = 'mL',
+  Unit = 'unit'
+}
 
 export enum AllergenEnum {
   Gluten = 'gluten',
@@ -37,597 +55,10 @@ export enum AllergenEnum {
   Mollusques = 'mollusques'
 }
 
-export type Category = {
-  __typename?: 'Category';
-  /** Unique primary key. */
-  id: Scalars['ID']['output'];
-  /** Category name. */
-  name: Scalars['String']['output'];
-  /** Ingredients in this category. */
-  ingredients: Array<Ingredient>;
-  /** Preparations in this category. */
-  preparations: Array<Preparation>;
-  /** The company that owns this category. */
-  company: Company;
-  /** Shelf life durations by location type. */
-  shelfLives: Array<CategoryShelfLife>;
-  /** When the Category was created. */
-  created_at: Scalars['DateTime']['output'];
-  /** When the Category was last updated. */
-  updated_at: Scalars['DateTime']['output'];
-};
-
-/** A paginated list of Category items. */
-export type CategoryPaginator = {
-  __typename?: 'CategoryPaginator';
-  /** Pagination information about the list of items. */
-  paginatorInfo: PaginatorInfo;
-  /** A list of Category items. */
-  data: Array<Category>;
-};
-
-export type CategoryShelfLife = {
-  __typename?: 'CategoryShelfLife';
-  /** The location type for this shelf life. */
-  locationType: LocationType;
-  /** Shelf life in hours for the category at this location type. */
-  shelf_life_hours: Scalars['Int']['output'];
-};
-
-export type Company = {
-  __typename?: 'Company';
-  /** Unique primary key. */
-  id: Scalars['ID']['output'];
-  /** Company name. */
-  name: Scalars['String']['output'];
-  /** Preparations associated with this company. */
-  preparations: Array<Preparation>;
-  categories: Array<Category>;
-  locations: Array<Location>;
-  /** Types de localisation associés à cette entreprise. */
-  locationTypes: Array<LocationType>;
-  /** Langue préférée pour les données OpenFoodFacts (fr ou en). */
-  open_food_facts_language?: Maybe<Scalars['String']['output']>;
-  /** Paramètres visibles publiquement pour la carte des menus. */
-  public_menu_settings: PublicMenuSettings;
-  /** Logo ou image de présentation de l'entreprise. */
-  logo_path?: Maybe<Scalars['String']['output']>;
-  /** Nom de la personne à contacter. */
-  contact_name?: Maybe<Scalars['String']['output']>;
-  /** Adresse e-mail de contact. */
-  contact_email?: Maybe<Scalars['String']['output']>;
-  /** Numéro de téléphone principal. */
-  contact_phone?: Maybe<Scalars['String']['output']>;
-  /** Ligne d'adresse principale. */
-  address_line?: Maybe<Scalars['String']['output']>;
-  /** Code postal. */
-  postal_code?: Maybe<Scalars['String']['output']>;
-  /** Ville. */
-  city?: Maybe<Scalars['String']['output']>;
-  /** Pays. */
-  country?: Maybe<Scalars['String']['output']>;
-  /** Horaires d'ouverture de la semaine. */
-  businessHours: Array<CompanyBusinessHour>;
-  /** When the company was created. */
-  created_at: Scalars['DateTime']['output'];
-  /** When the company was last updated. */
-  updated_at: Scalars['DateTime']['output'];
-};
-
-export type CompanyBusinessHour = {
-  __typename?: 'CompanyBusinessHour';
-  id: Scalars['ID']['output'];
-  day_of_week: Scalars['Int']['output'];
-  opens_at: Scalars['String']['output'];
-  closes_at: Scalars['String']['output'];
-  is_overnight: Scalars['Boolean']['output'];
-  sequence: Scalars['Int']['output'];
-  created_at: Scalars['DateTime']['output'];
-  updated_at: Scalars['DateTime']['output'];
-};
-
-/** Champs disponibles pour le tri des entreprises. */
-export enum CompanyOrderByField {
-  Id = 'ID',
-  Name = 'NAME',
-  CreatedAt = 'CREATED_AT',
-  UpdatedAt = 'UPDATED_AT'
-}
-
-/** Options de tri pour les entreprises. */
-export type CompanyOrderByOrderByClause = {
-  /** Champ sur lequel effectuer le tri. */
-  field: CompanyOrderByField;
-  /** Direction du tri. */
-  order: SortOrder;
-};
-
-/** A paginated list of Company items. */
-export type CompanyPaginator = {
-  __typename?: 'CompanyPaginator';
-  /** Pagination information about the list of items. */
-  paginatorInfo: PaginatorInfo;
-  /** A list of Company items. */
-  data: Array<Company>;
-};
-
-export type Ingredient = {
-  __typename?: 'Ingredient';
-  /** Unique primary key. */
-  id: Scalars['ID']['output'];
-  /** Ingredient name. */
-  name: Scalars['String']['output'];
-  /** Unit of measurement for the ingredient. */
-  unit: UnitEnum;
-  /** Quantity for one unit of the ingredient. */
-  base_quantity: Scalars['Float']['output'];
-  /** Unit for the base quantity of the ingredient. */
-  base_unit: UnitEnum;
-  /** Optional minimum stock quantity before alerting. */
-  threshold?: Maybe<Scalars['Float']['output']>;
-  /** Allergens contained in the ingredient. */
-  allergens: Array<AllergenEnum>;
-  quantities: Array<IngredientQuantity>;
-  /** The company that owns this ingredient. */
-  company: Company;
-  category: Category;
-  image_url?: Maybe<Scalars['String']['output']>;
-  /** Historique des mouvements de stock pour cet ingrédient */
-  stockMovements: Array<StockMovement>;
-  withdrawals_today_count: Scalars['Int']['output'];
-  /** Number of withdrawals for this ingredient today. */
-  withdrawals_this_week_count: Scalars['Int']['output'];
-  /** Number of withdrawals for this ingredient this week. */
-  withdrawals_this_month_count: Scalars['Int']['output'];
-  /** When the ingredient was created. */
-  created_at: Scalars['DateTime']['output'];
-  /** When the ingredient was last updated. */
-  updated_at: Scalars['DateTime']['output'];
-};
-
-
-export type IngredientStockMovementsArgs = {
-  orderBy?: InputMaybe<Array<StockMovementOrderByClause>>;
-};
-
-export type IngredientOrderByClause = {
-  column: IngredientOrderByField;
-  order?: SortOrder;
-};
-
-export enum IngredientOrderByField {
-  Id = 'ID',
-  Name = 'NAME',
-  CreatedAt = 'CREATED_AT',
-  UpdatedAt = 'UPDATED_AT',
-  WithdrawalsToday = 'WITHDRAWALS_TODAY',
-  WithdrawalsThisWeek = 'WITHDRAWALS_THIS_WEEK',
-  WithdrawalsThisMonth = 'WITHDRAWALS_THIS_MONTH'
-}
-
-/** A paginated list of Ingredient items. */
-export type IngredientPaginator = {
-  __typename?: 'IngredientPaginator';
-  /** Pagination information about the list of items. */
-  paginatorInfo: PaginatorInfo;
-  /** A list of Ingredient items. */
-  data: Array<Ingredient>;
-};
-
-export type IngredientQuantity = {
-  __typename?: 'IngredientQuantity';
-  /** Le stock de l'ingrédient. */
-  quantity: Scalars['Float']['output'];
-  /** La localisation de ce stock. */
-  location: Location;
-};
-
-export type Location = {
-  __typename?: 'Location';
-  /** Unique primary key. */
-  id: Scalars['ID']['output'];
-  /** Location name. */
-  name: Scalars['String']['output'];
-  /** Location company. */
-  company: Company;
-  /** Type de localisation (Congélateur, Réfrigérateur, etc.) */
-  locationType?: Maybe<LocationType>;
-  /** When the location was created. */
-  created_at: Scalars['DateTime']['output'];
-  /** When the location was last updated. */
-  updated_at: Scalars['DateTime']['output'];
-  /** Ingredients stored in this location. */
-  ingredients: Array<Ingredient>;
-};
-
-/** Champs disponibles pour le tri des emplacements. */
-export enum LocationOrderByField {
-  Id = 'ID',
-  Name = 'NAME',
-  CreatedAt = 'CREATED_AT',
-  UpdatedAt = 'UPDATED_AT'
-}
-
-/** Options de tri pour les emplacements. */
-export type LocationOrderByOrderByClause = {
-  /** Champ sur lequel effectuer le tri. */
-  field: LocationOrderByField;
-  /** Direction du tri. */
-  order: SortOrder;
-};
-
-/** A paginated list of Location items. */
-export type LocationPaginator = {
-  __typename?: 'LocationPaginator';
-  /** Pagination information about the list of items. */
-  paginatorInfo: PaginatorInfo;
-  /** A list of Location items. */
-  data: Array<Location>;
-};
-
-/** Type de localisation pour organiser les emplacements de stockage */
-export type LocationType = {
-  __typename?: 'LocationType';
-  /** Identifiant unique. */
-  id: Scalars['ID']['output'];
-  /** Nom du type de localisation. */
-  name: Scalars['String']['output'];
-  /** Indique si c'est un type par défaut (non modifiable). */
-  is_default: Scalars['Boolean']['output'];
-  /** L'entreprise à laquelle appartient ce type. */
-  company: Company;
-  /** Emplacements utilisant ce type de localisation. */
-  locations: Array<Location>;
-  /** Date de création du type. */
-  created_at: Scalars['DateTime']['output'];
-  /** Date de dernière mise à jour du type. */
-  updated_at: Scalars['DateTime']['output'];
-};
-
-/** Champs disponibles pour le tri des types de localisation. */
-export enum LocationTypeOrderByField {
-  Id = 'ID',
-  Name = 'NAME',
-  IsDefault = 'IS_DEFAULT',
-  CreatedAt = 'CREATED_AT',
-  UpdatedAt = 'UPDATED_AT'
-}
-
-/** Options de tri pour les types de localisation. */
-export type LocationTypeOrderByOrderByClause = {
-  /** Champ sur lequel effectuer le tri. */
-  field: LocationTypeOrderByField;
-  /** Direction du tri. */
-  order: SortOrder;
-};
-
-/** A paginated list of LocationType items. */
-export type LocationTypePaginator = {
-  __typename?: 'LocationTypePaginator';
-  /** Pagination information about the list of items. */
-  paginatorInfo: PaginatorInfo;
-  /** A list of LocationType items. */
-  data: Array<LocationType>;
-};
-
-/** Représente une perte d'ingrédient ou de préparation. */
-export type Loss = {
-  __typename?: 'Loss';
-  /** Identifiant unique. */
-  id: Scalars['ID']['output'];
-  /** Type d'entité concernée par cette perte (ingredient ou preparation). */
-  loss_item_type: Scalars['String']['output'];
-  /** ID de l'entité concernée. */
-  loss_item_id: Scalars['ID']['output'];
-  /** L'emplacement où la perte a eu lieu. */
-  location: Location;
-  /** L'entreprise à laquelle appartient cette perte. */
-  company: Company;
-  /** L'utilisateur qui a enregistré la perte. */
-  user?: Maybe<User>;
-  /** Quantité perdue. */
-  quantity: Scalars['Float']['output'];
-  /** Raison de la perte. */
-  reason: Scalars['String']['output'];
-  /** Date et heure de création de la perte. */
-  created_at: Scalars['DateTime']['output'];
-  /** Date et heure de dernière mise à jour de la perte. */
-  updated_at: Scalars['DateTime']['output'];
-};
-
-/** Statistiques des pertes par type. */
-export type LossesStats = {
-  __typename?: 'LossesStats';
-  ingredient: Scalars['Float']['output'];
-  preparation: Scalars['Float']['output'];
-  total: Scalars['Float']['output'];
-};
-
-export type LossOrderByClause = {
-  field: LossOrderByField;
-  order: SortOrder;
-};
-
-export enum LossOrderByField {
-  Id = 'ID',
-  Quantity = 'QUANTITY',
-  CreatedAt = 'CREATED_AT',
-  UpdatedAt = 'UPDATED_AT'
-}
-
-/** A paginated list of Loss items. */
-export type LossPaginator = {
-  __typename?: 'LossPaginator';
-  /** Pagination information about the list of items. */
-  paginatorInfo: PaginatorInfo;
-  /** A list of Loss items. */
-  data: Array<Loss>;
-};
-
-/** Raison de perte prédéfinie pour une entreprise. */
-export type LossReason = {
-  __typename?: 'LossReason';
-  /** Identifiant unique. */
-  id: Scalars['ID']['output'];
-  /** Nom de la raison. */
-  name: Scalars['String']['output'];
-  /** Entreprise associée. */
-  company: Company;
-  /** Date de création. */
-  created_at: Scalars['DateTime']['output'];
-  /** Date de mise à jour. */
-  updated_at: Scalars['DateTime']['output'];
-};
-
-/** Type représentant une unité de mesure */
-export type MeasurementUnitType = {
-  __typename?: 'MeasurementUnitType';
-  /** Valeur utilisée en interne (ex: 'kg', 'L') */
-  value: Scalars['String']['output'];
-  /** Libellé français (ex: 'Kilogramme (kg)') */
-  label: Scalars['String']['output'];
-  /** Catégorie de l'unité (masse, volume ou unité) */
-  category: Scalars['String']['output'];
-};
-
-export type Menu = {
-  __typename?: 'Menu';
-  id: Scalars['ID']['output'];
-  name: Scalars['String']['output'];
-  description?: Maybe<Scalars['String']['output']>;
-  image_url?: Maybe<Scalars['String']['output']>;
-  is_a_la_carte: Scalars['Boolean']['output'];
-  service_type: MenuServiceTypeEnum;
-  is_returnable: Scalars['Boolean']['output'];
-  available: Scalars['Boolean']['output'];
-  type: Scalars['String']['output'];
-  menu_type_id: Scalars['ID']['output'];
-  public_priority: Scalars['Int']['output'];
-  menu_type?: Maybe<MenuType>;
-  price: Scalars['Float']['output'];
-  categories: Array<MenuCategory>;
-  allergens: Array<AllergenEnum>;
-  items: Array<MenuItem>;
-  created_at: Scalars['DateTime']['output'];
-  updated_at: Scalars['DateTime']['output'];
-};
-
-
-export type MenuAvailableArgs = {
-  quantity?: Scalars['Int']['input'];
-};
-
-export type MenuCategory = {
-  __typename?: 'MenuCategory';
-  /** Unique primary key. */
-  id: Scalars['ID']['output'];
-  /** Category name. */
-  name: Scalars['String']['output'];
-  /** Menus in this category. */
-  menus: Array<Menu>;
-  /** The company that owns this category. */
-  company: Company;
-  /** When the category was created. */
-  created_at: Scalars['DateTime']['output'];
-  /** When the category was last updated. */
-  updated_at: Scalars['DateTime']['output'];
-};
-
-/** A paginated list of MenuCategory items. */
-export type MenuCategoryPaginator = {
-  __typename?: 'MenuCategoryPaginator';
-  /** Pagination information about the list of items. */
-  paginatorInfo: PaginatorInfo;
-  /** A list of MenuCategory items. */
-  data: Array<MenuCategory>;
-};
-
-export type MenuItem = {
-  __typename?: 'MenuItem';
-  id: Scalars['ID']['output'];
-  location: Location;
-  quantity: Scalars['Float']['output'];
-  unit: UnitEnum;
-  entity: MenuItemEntity;
-};
-
-export type MenuItemEntity = Ingredient | Preparation;
-
-/** A paginated list of Menu items. */
-export type MenuPaginator = {
-  __typename?: 'MenuPaginator';
-  /** Pagination information about the list of items. */
-  paginatorInfo: PaginatorInfo;
-  /** A list of Menu items. */
-  data: Array<Menu>;
-};
-
 export enum MenuServiceTypeEnum {
   Prep = 'PREP',
   Direct = 'DIRECT'
 }
-
-export type MenuType = {
-  __typename?: 'MenuType';
-  id: Scalars['ID']['output'];
-  name: Scalars['String']['output'];
-  public_index: Scalars['Int']['output'];
-};
-
-/** Représente un produit alimentaire issu d'OpenFoodFacts */
-export type OpenFoodFactsProduct = {
-  __typename?: 'OpenFoodFactsProduct';
-  barcode?: Maybe<Scalars['String']['output']>;
-  product_name?: Maybe<Scalars['String']['output']>;
-  base_quantity?: Maybe<Scalars['Float']['output']>;
-  unit?: Maybe<Scalars['String']['output']>;
-  categories?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
-  imageUrl?: Maybe<Scalars['String']['output']>;
-  is_already_in_database?: Maybe<Scalars['Boolean']['output']>;
-  ingredient_id?: Maybe<Scalars['ID']['output']>;
-};
-
-/** Représente une commande passée dans l'établissement. */
-export type Order = {
-  __typename?: 'Order';
-  /** Identifiant unique. */
-  id: Scalars['ID']['output'];
-  /** Table associée à la commande. */
-  table: Table;
-  /** Entreprise propriétaire de la commande. */
-  company: Company;
-  /** Utilisateur qui a créé la commande. */
-  user: User;
-  /** Statut actuel de la commande. */
-  status: OrderStatusEnum;
-  /** Horodatage du passage de la commande en statut PENDING. */
-  pending_at?: Maybe<Scalars['DateTime']['output']>;
-  /** Horodatage du service de la commande. */
-  served_at?: Maybe<Scalars['DateTime']['output']>;
-  /** Horodatage du paiement de la commande. */
-  payed_at?: Maybe<Scalars['DateTime']['output']>;
-  /** Horodatage de l'annulation éventuelle. */
-  canceled_at?: Maybe<Scalars['DateTime']['output']>;
-  /** Prix total TTC calculé à partir des menus de toutes les étapes (prix × quantité). */
-  price: Scalars['Float']['output'];
-  /** Étapes associées à la commande. */
-  steps: Array<OrderStep>;
-  /** Historique des actions liées à la commande (ordre chronologique). */
-  histories: Array<OrderHistory>;
-  /** Date de création de la commande. */
-  created_at: Scalars['DateTime']['output'];
-  /** Date de dernière mise à jour. */
-  updated_at: Scalars['DateTime']['output'];
-};
-
-/** Allows ordering a list of records. */
-export type OrderByClause = {
-  /** The column that is used for ordering. */
-  column: Scalars['String']['input'];
-  /** The direction that is used for ordering. */
-  order: SortOrder;
-};
-
-/** Aggregate functions when ordering by a relation without specifying a column. */
-export enum OrderByRelationAggregateFunction {
-  /** Amount of items. */
-  Count = 'COUNT'
-}
-
-/** Aggregate functions when ordering by a relation that may specify a column. */
-export enum OrderByRelationWithColumnAggregateFunction {
-  /** Average. */
-  Avg = 'AVG',
-  /** Minimum. */
-  Min = 'MIN',
-  /** Maximum. */
-  Max = 'MAX',
-  /** Sum. */
-  Sum = 'SUM',
-  /** Amount of items. */
-  Count = 'COUNT'
-}
-
-/** Historique des actions effectuées sur une commande. */
-export type OrderHistory = {
-  __typename?: 'OrderHistory';
-  /** Identifiant unique de l'entrée. */
-  id: Scalars['ID']['output'];
-  /** Commande associée à l'entrée. */
-  order: Order;
-  /** Étape concernée, le cas échéant. */
-  order_step?: Maybe<OrderStep>;
-  /** Menu d'étape concerné, le cas échéant. */
-  step_menu?: Maybe<StepMenu>;
-  /** Entreprise liée à l'entrée. */
-  company: Company;
-  /** Utilisateur ayant réalisé l'action. */
-  user?: Maybe<User>;
-  /** Type d'action enregistrée. */
-  action: OrderHistoryActionEnum;
-  /** Informations métier associées à l'action. */
-  payload?: Maybe<Scalars['JSON']['output']>;
-  /** Raison associée à l'action (si applicable). */
-  reason?: Maybe<Scalars['String']['output']>;
-  /** Date de création de l'entrée. */
-  created_at: Scalars['DateTime']['output'];
-  /** Date de dernière mise à jour. */
-  updated_at: Scalars['DateTime']['output'];
-};
-
-/** Liste des actions possibles sur l'historique des commandes. */
-export enum OrderHistoryActionEnum {
-  OrderCreated = 'ORDER_CREATED',
-  OrderStatusUpdated = 'ORDER_STATUS_UPDATED',
-  OrderStepCreated = 'ORDER_STEP_CREATED',
-  OrderStepStatusUpdated = 'ORDER_STEP_STATUS_UPDATED',
-  StepMenuAdded = 'STEP_MENU_ADDED',
-  StepMenuUpdated = 'STEP_MENU_UPDATED',
-  StepMenuRemoved = 'STEP_MENU_REMOVED',
-  StepMenuStatusUpdated = 'STEP_MENU_STATUS_UPDATED'
-}
-
-/** Options de tri disponibles pour les commandes. */
-export type OrderOrderByClause = {
-  /** Colonne utilisée pour le tri. */
-  column: OrderOrderByField;
-  /** Direction du tri. */
-  order?: SortOrder;
-};
-
-/** Colonnes triables pour les commandes. */
-export enum OrderOrderByField {
-  Id = 'ID',
-  Status = 'STATUS',
-  TableId = 'TABLE_ID',
-  UserId = 'USER_ID',
-  PendingAt = 'PENDING_AT',
-  ServedAt = 'SERVED_AT',
-  PayedAt = 'PAYED_AT',
-  CanceledAt = 'CANCELED_AT',
-  CreatedAt = 'CREATED_AT',
-  UpdatedAt = 'UPDATED_AT'
-}
-
-/** A paginated list of Order items. */
-export type OrderPaginator = {
-  __typename?: 'OrderPaginator';
-  /** Pagination information about the list of items. */
-  paginatorInfo: PaginatorInfo;
-  /** A list of Order items. */
-  data: Array<Order>;
-};
-
-/** Statistiques agrégées sur les commandes. */
-export type OrdersStats = {
-  __typename?: 'OrdersStats';
-  pending: Scalars['Int']['output'];
-  served: Scalars['Int']['output'];
-  payed: Scalars['Int']['output'];
-  canceled: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
-  revenue: Scalars['Float']['output'];
-};
 
 export enum OrderStatusEnum {
   Pending = 'PENDING',
@@ -636,203 +67,17 @@ export enum OrderStatusEnum {
   Canceled = 'CANCELED'
 }
 
-/** Étape individuelle d'une commande. */
-export type OrderStep = {
-  __typename?: 'OrderStep';
-  /** Identifiant unique. */
-  id: Scalars['ID']['output'];
-  /** Commande à laquelle appartient l'étape. */
-  order: Order;
-  /** Position de l'étape dans le flux de service. */
-  position: Scalars['Int']['output'];
-  /** Statut actuel de l'étape. */
-  status: OrderStepStatusEnum;
-  /** Horodatage du service de l'étape. */
-  served_at?: Maybe<Scalars['DateTime']['output']>;
-  /** Prix TTC de l'étape calculé en sommant prix × quantité des menus associés. */
-  price: Scalars['Float']['output'];
-  /** Menus associés à cette étape. */
-  stepMenus: Array<StepMenu>;
-  /** Menus liés via la relation pivot. */
-  menus: Array<Menu>;
-  /** Date de création de l'étape. */
-  created_at: Scalars['DateTime']['output'];
-  /** Date de dernière mise à jour. */
-  updated_at: Scalars['DateTime']['output'];
-};
-
-/** Options de tri disponibles pour les étapes de commande. */
-export type OrderStepOrderByClause = {
-  /** Colonne utilisée pour le tri. */
-  column: OrderStepOrderByField;
-  /** Direction du tri. */
-  order?: SortOrder;
-};
-
-/** Colonnes triables pour les étapes de commande. */
-export enum OrderStepOrderByField {
-  Id = 'ID',
-  OrderId = 'ORDER_ID',
-  Position = 'POSITION',
-  Status = 'STATUS',
-  ServedAt = 'SERVED_AT',
-  CreatedAt = 'CREATED_AT',
-  UpdatedAt = 'UPDATED_AT'
-}
-
-/** A paginated list of OrderStep items. */
-export type OrderStepPaginator = {
-  __typename?: 'OrderStepPaginator';
-  /** Pagination information about the list of items. */
-  paginatorInfo: PaginatorInfo;
-  /** A list of OrderStep items. */
-  data: Array<OrderStep>;
-};
-
 export enum OrderStepStatusEnum {
   InPrep = 'IN_PREP',
   Ready = 'READY',
   Served = 'SERVED'
 }
 
-/** Information about pagination using a fully featured paginator. */
-export type PaginatorInfo = {
-  __typename?: 'PaginatorInfo';
-  /** Number of items in the current page. */
-  count: Scalars['Int']['output'];
-  /** Index of the current page. */
-  currentPage: Scalars['Int']['output'];
-  /** Index of the first item in the current page. */
-  firstItem?: Maybe<Scalars['Int']['output']>;
-  /** Are there more pages after this one? */
-  hasMorePages: Scalars['Boolean']['output'];
-  /** Index of the last item in the current page. */
-  lastItem?: Maybe<Scalars['Int']['output']>;
-  /** Index of the last available page. */
-  lastPage: Scalars['Int']['output'];
-  /** Number of items per page. */
-  perPage: Scalars['Int']['output'];
-  /** Number of total available items. */
-  total: Scalars['Int']['output'];
-};
-
-export type Perishable = {
-  __typename?: 'Perishable';
-  id: Scalars['ID']['output'];
-  ingredient: Ingredient;
-  location: Location;
-  quantity: Scalars['Float']['output'];
-  is_read: Scalars['Boolean']['output'];
-  expiration_at: Scalars['DateTime']['output'];
-  created_at: Scalars['DateTime']['output'];
-  updated_at: Scalars['DateTime']['output'];
-};
-
-export enum PerishableFilter {
-  Fresh = 'FRESH',
-  Soon = 'SOON',
-  Expired = 'EXPIRED'
+export enum StepMenuStatusEnum {
+  InPrep = 'IN_PREP',
+  Ready = 'READY',
+  Served = 'SERVED'
 }
-
-export type Preparation = {
-  __typename?: 'Preparation';
-  /** Unique primary key. */
-  id: Scalars['ID']['output'];
-  /** Preparation name. */
-  name: Scalars['String']['output'];
-  /** Unit of measurement for the preparation. */
-  unit: UnitEnum;
-  /** Quantity for one unit of the preparation. */
-  base_quantity: Scalars['Float']['output'];
-  /** Unit for the base quantity of the preparation. */
-  base_unit: UnitEnum;
-  /** Allergens contained in this preparation. */
-  allergens: Array<AllergenEnum>;
-  /** The company that produces this preparation. */
-  company: Company;
-  /** Threshold below which the preparation is considered understocked. */
-  threshold?: Maybe<Scalars['Float']['output']>;
-  entities: Array<PreparationEntity>;
-  locations: Array<Location>;
-  /** The categories associated with this preparation. */
-  categories: Array<Category>;
-  quantities: Array<PreparationQuantity>;
-  preparable_quantity: PreparationPreparableQuantity;
-  image_url?: Maybe<Scalars['String']['output']>;
-  /** Historique des mouvements de stock pour cette préparation */
-  stockMovements: Array<StockMovement>;
-  withdrawals_today_count: Scalars['Int']['output'];
-  /** Number of withdrawals for this ingredient today. */
-  withdrawals_this_week_count: Scalars['Int']['output'];
-  /** Number of withdrawals for this ingredient this week. */
-  withdrawals_this_month_count: Scalars['Int']['output'];
-  /** When the preparation was created. */
-  created_at: Scalars['DateTime']['output'];
-  /** When the preparation was last updated. */
-  updated_at: Scalars['DateTime']['output'];
-};
-
-export type PreparationEntity = {
-  __typename?: 'PreparationEntity';
-  id: Scalars['ID']['output'];
-  entity: PreparationEntityItem;
-  preparation: Preparation;
-  location: Location;
-  quantity: Scalars['Float']['output'];
-  unit: UnitEnum;
-};
-
-export type PreparationEntityItem = Ingredient | Preparation;
-
-export type PreparationOrderByClause = {
-  column: PreparationOrderByField;
-  order?: SortOrder;
-};
-
-export enum PreparationOrderByField {
-  Id = 'ID',
-  Name = 'NAME',
-  CreatedAt = 'CREATED_AT',
-  UpdatedAt = 'UPDATED_AT',
-  WithdrawalsToday = 'WITHDRAWALS_TODAY',
-  WithdrawalsThisWeek = 'WITHDRAWALS_THIS_WEEK',
-  WithdrawalsThisMonth = 'WITHDRAWALS_THIS_MONTH'
-}
-
-/** A paginated list of Preparation items. */
-export type PreparationPaginator = {
-  __typename?: 'PreparationPaginator';
-  /** Pagination information about the list of items. */
-  paginatorInfo: PaginatorInfo;
-  /** A list of Preparation items. */
-  data: Array<Preparation>;
-};
-
-export type PreparationPreparableQuantity = {
-  __typename?: 'PreparationPreparableQuantity';
-  /** Quantité maximale préparable avec le stock actuel. */
-  quantity: Scalars['Float']['output'];
-  /** Unité associée à la préparation. */
-  unit: UnitEnum;
-};
-
-export type PreparationQuantity = {
-  __typename?: 'PreparationQuantity';
-  /** Le stock de la préparation. */
-  quantity: Scalars['Float']['output'];
-  /** La localisation de ce stock. */
-  location: Location;
-};
-
-export type PublicMenuSettings = {
-  __typename?: 'PublicMenuSettings';
-  /** Identifiant public unique pour partager la carte du restaurant. */
-  public_menu_card_url: Scalars['String']['output'];
-  /** Affiche aussi les menus qui n'ont pas assez de stock sur la carte publique. */
-  show_out_of_stock_menus_on_card: Scalars['Boolean']['output'];
-  /** Affiche les images des menus sur la carte publique. */
-  show_menu_images: Scalars['Boolean']['output'];
-};
 
 export type Query = {
   __typename?: 'Query';
@@ -1201,45 +446,631 @@ export type QueryUsersArgs = {
   page?: InputMaybe<Scalars['Int']['input']>;
 };
 
-/** Order by clause for Query.orders.orderBy. */
-export type QueryOrdersOrderByOrderByClause = {
-  /** The column that is used for ordering. */
+/** Directions for ordering a list of records. */
+export enum SortOrder {
+  /** Sort records in ascending order. */
+  Asc = 'ASC',
+  /** Sort records in descending order. */
+  Desc = 'DESC'
+}
+
+export type Category = {
+  __typename?: 'Category';
+  /** Unique primary key. */
+  id: Scalars['ID']['output'];
+  /** Category name. */
+  name: Scalars['String']['output'];
+  /** Ingredients in this category. */
+  ingredients: Array<Ingredient>;
+  /** Preparations in this category. */
+  preparations: Array<Preparation>;
+  /** The company that owns this category. */
+  company: Company;
+  /** Shelf life durations by location type. */
+  shelfLives: Array<CategoryShelfLife>;
+  /** When the Category was created. */
+  created_at: Scalars['DateTime']['output'];
+  /** When the Category was last updated. */
+  updated_at: Scalars['DateTime']['output'];
+};
+
+export type CategoryShelfLife = {
+  __typename?: 'CategoryShelfLife';
+  /** The location type for this shelf life. */
+  locationType: LocationType;
+  /** Shelf life in hours for the category at this location type. */
+  shelf_life_hours: Scalars['Int']['output'];
+};
+
+export type Company = {
+  __typename?: 'Company';
+  /** Unique primary key. */
+  id: Scalars['ID']['output'];
+  /** Company name. */
+  name: Scalars['String']['output'];
+  /** Preparations associated with this company. */
+  preparations: Array<Preparation>;
+  categories: Array<Category>;
+  locations: Array<Location>;
+  /** Types de localisation associés à cette entreprise. */
+  locationTypes: Array<LocationType>;
+  /** Langue préférée pour les données OpenFoodFacts (fr ou en). */
+  open_food_facts_language?: Maybe<Scalars['String']['output']>;
+  /** Paramètres visibles publiquement pour la carte des menus. */
+  public_menu_settings: PublicMenuSettings;
+  /** Logo ou image de présentation de l'entreprise. */
+  logo_path?: Maybe<Scalars['String']['output']>;
+  /** Nom de la personne à contacter. */
+  contact_name?: Maybe<Scalars['String']['output']>;
+  /** Adresse e-mail de contact. */
+  contact_email?: Maybe<Scalars['String']['output']>;
+  /** Numéro de téléphone principal. */
+  contact_phone?: Maybe<Scalars['String']['output']>;
+  /** Ligne d'adresse principale. */
+  address_line?: Maybe<Scalars['String']['output']>;
+  /** Code postal. */
+  postal_code?: Maybe<Scalars['String']['output']>;
+  /** Ville. */
+  city?: Maybe<Scalars['String']['output']>;
+  /** Pays. */
+  country?: Maybe<Scalars['String']['output']>;
+  /** Horaires d'ouverture de la semaine. */
+  businessHours: Array<CompanyBusinessHour>;
+  /** When the company was created. */
+  created_at: Scalars['DateTime']['output'];
+  /** When the company was last updated. */
+  updated_at: Scalars['DateTime']['output'];
+};
+
+export type CompanyBusinessHour = {
+  __typename?: 'CompanyBusinessHour';
+  id: Scalars['ID']['output'];
+  day_of_week: Scalars['Int']['output'];
+  opens_at: Scalars['String']['output'];
+  closes_at: Scalars['String']['output'];
+  is_overnight: Scalars['Boolean']['output'];
+  sequence: Scalars['Int']['output'];
+  created_at: Scalars['DateTime']['output'];
+  updated_at: Scalars['DateTime']['output'];
+};
+
+/** Options de tri pour les entreprises. */
+export type CompanyOrderByOrderByClause = {
+  /** Champ sur lequel effectuer le tri. */
+  field: CompanyOrderByField;
+  /** Direction du tri. */
+  order: SortOrder;
+};
+
+/** Champs disponibles pour le tri des entreprises. */
+export enum CompanyOrderByField {
+  Id = 'ID',
+  Name = 'NAME',
+  CreatedAt = 'CREATED_AT',
+  UpdatedAt = 'UPDATED_AT'
+}
+
+export type PublicMenuSettings = {
+  __typename?: 'PublicMenuSettings';
+  /** Identifiant public unique pour partager la carte du restaurant. */
+  public_menu_card_url: Scalars['String']['output'];
+  /** Affiche aussi les menus qui n'ont pas assez de stock sur la carte publique. */
+  show_out_of_stock_menus_on_card: Scalars['Boolean']['output'];
+  /** Affiche les images des menus sur la carte publique. */
+  show_menu_images: Scalars['Boolean']['output'];
+};
+
+export type Ingredient = {
+  __typename?: 'Ingredient';
+  /** Unique primary key. */
+  id: Scalars['ID']['output'];
+  /** Ingredient name. */
+  name: Scalars['String']['output'];
+  /** Unit of measurement for the ingredient. */
+  unit: UnitEnum;
+  /** Quantity for one unit of the ingredient. */
+  base_quantity: Scalars['Float']['output'];
+  /** Unit for the base quantity of the ingredient. */
+  base_unit: UnitEnum;
+  /** Optional minimum stock quantity before alerting. */
+  threshold?: Maybe<Scalars['Float']['output']>;
+  /** Allergens contained in the ingredient. */
+  allergens: Array<AllergenEnum>;
+  quantities: Array<IngredientQuantity>;
+  /** The company that owns this ingredient. */
+  company: Company;
+  category: Category;
+  image_url?: Maybe<Scalars['String']['output']>;
+  /** Historique des mouvements de stock pour cet ingrédient */
+  stockMovements: Array<StockMovement>;
+  withdrawals_today_count: Scalars['Int']['output'];
+  /** Number of withdrawals for this ingredient today. */
+  withdrawals_this_week_count: Scalars['Int']['output'];
+  /** Number of withdrawals for this ingredient this week. */
+  withdrawals_this_month_count: Scalars['Int']['output'];
+  /** When the ingredient was created. */
+  created_at: Scalars['DateTime']['output'];
+  /** When the ingredient was last updated. */
+  updated_at: Scalars['DateTime']['output'];
+};
+
+
+export type IngredientStockMovementsArgs = {
+  orderBy?: InputMaybe<Array<StockMovementOrderByClause>>;
+};
+
+export enum IngredientOrderByField {
+  Id = 'ID',
+  Name = 'NAME',
+  CreatedAt = 'CREATED_AT',
+  UpdatedAt = 'UPDATED_AT',
+  WithdrawalsToday = 'WITHDRAWALS_TODAY',
+  WithdrawalsThisWeek = 'WITHDRAWALS_THIS_WEEK',
+  WithdrawalsThisMonth = 'WITHDRAWALS_THIS_MONTH'
+}
+
+export type IngredientOrderByClause = {
+  column: IngredientOrderByField;
+  order?: SortOrder;
+};
+
+export type IngredientQuantity = {
+  __typename?: 'IngredientQuantity';
+  /** Le stock de l'ingrédient. */
+  quantity: Scalars['Float']['output'];
+  /** La localisation de ce stock. */
+  location: Location;
+};
+
+export type Location = {
+  __typename?: 'Location';
+  /** Unique primary key. */
+  id: Scalars['ID']['output'];
+  /** Location name. */
+  name: Scalars['String']['output'];
+  /** Location company. */
+  company: Company;
+  /** Type de localisation (Congélateur, Réfrigérateur, etc.) */
+  locationType?: Maybe<LocationType>;
+  /** When the location was created. */
+  created_at: Scalars['DateTime']['output'];
+  /** When the location was last updated. */
+  updated_at: Scalars['DateTime']['output'];
+  /** Ingredients stored in this location. */
+  ingredients: Array<Ingredient>;
+};
+
+/** Options de tri pour les emplacements. */
+export type LocationOrderByOrderByClause = {
+  /** Champ sur lequel effectuer le tri. */
+  field: LocationOrderByField;
+  /** Direction du tri. */
+  order: SortOrder;
+};
+
+/** Champs disponibles pour le tri des emplacements. */
+export enum LocationOrderByField {
+  Id = 'ID',
+  Name = 'NAME',
+  CreatedAt = 'CREATED_AT',
+  UpdatedAt = 'UPDATED_AT'
+}
+
+/** Type de localisation pour organiser les emplacements de stockage */
+export type LocationType = {
+  __typename?: 'LocationType';
+  /** Identifiant unique. */
+  id: Scalars['ID']['output'];
+  /** Nom du type de localisation. */
+  name: Scalars['String']['output'];
+  /** Indique si c'est un type par défaut (non modifiable). */
+  is_default: Scalars['Boolean']['output'];
+  /** L'entreprise à laquelle appartient ce type. */
+  company: Company;
+  /** Emplacements utilisant ce type de localisation. */
+  locations: Array<Location>;
+  /** Date de création du type. */
+  created_at: Scalars['DateTime']['output'];
+  /** Date de dernière mise à jour du type. */
+  updated_at: Scalars['DateTime']['output'];
+};
+
+/** Options de tri pour les types de localisation. */
+export type LocationTypeOrderByOrderByClause = {
+  /** Champ sur lequel effectuer le tri. */
+  field: LocationTypeOrderByField;
+  /** Direction du tri. */
+  order: SortOrder;
+};
+
+/** Champs disponibles pour le tri des types de localisation. */
+export enum LocationTypeOrderByField {
+  Id = 'ID',
+  Name = 'NAME',
+  IsDefault = 'IS_DEFAULT',
+  CreatedAt = 'CREATED_AT',
+  UpdatedAt = 'UPDATED_AT'
+}
+
+/** Représente une perte d'ingrédient ou de préparation. */
+export type Loss = {
+  __typename?: 'Loss';
+  /** Identifiant unique. */
+  id: Scalars['ID']['output'];
+  /** Type d'entité concernée par cette perte (ingredient ou preparation). */
+  loss_item_type: Scalars['String']['output'];
+  /** ID de l'entité concernée. */
+  loss_item_id: Scalars['ID']['output'];
+  /** L'emplacement où la perte a eu lieu. */
+  location: Location;
+  /** L'entreprise à laquelle appartient cette perte. */
+  company: Company;
+  /** L'utilisateur qui a enregistré la perte. */
+  user?: Maybe<User>;
+  /** Quantité perdue. */
+  quantity: Scalars['Float']['output'];
+  /** Raison de la perte. */
+  reason: Scalars['String']['output'];
+  /** Date et heure de création de la perte. */
+  created_at: Scalars['DateTime']['output'];
+  /** Date et heure de dernière mise à jour de la perte. */
+  updated_at: Scalars['DateTime']['output'];
+};
+
+/** Statistiques des pertes par type. */
+export type LossesStats = {
+  __typename?: 'LossesStats';
+  ingredient: Scalars['Float']['output'];
+  preparation: Scalars['Float']['output'];
+  total: Scalars['Float']['output'];
+};
+
+export type LossOrderByClause = {
+  field: LossOrderByField;
+  order: SortOrder;
+};
+
+export enum LossOrderByField {
+  Id = 'ID',
+  Quantity = 'QUANTITY',
+  CreatedAt = 'CREATED_AT',
+  UpdatedAt = 'UPDATED_AT'
+}
+
+/** Raison de perte prédéfinie pour une entreprise. */
+export type LossReason = {
+  __typename?: 'LossReason';
+  /** Identifiant unique. */
+  id: Scalars['ID']['output'];
+  /** Nom de la raison. */
+  name: Scalars['String']['output'];
+  /** Entreprise associée. */
+  company: Company;
+  /** Date de création. */
+  created_at: Scalars['DateTime']['output'];
+  /** Date de mise à jour. */
+  updated_at: Scalars['DateTime']['output'];
+};
+
+/** Type représentant une unité de mesure */
+export type MeasurementUnitType = {
+  __typename?: 'MeasurementUnitType';
+  /** Valeur utilisée en interne (ex: 'kg', 'L') */
+  value: Scalars['String']['output'];
+  /** Libellé français (ex: 'Kilogramme (kg)') */
+  label: Scalars['String']['output'];
+  /** Catégorie de l'unité (masse, volume ou unité) */
+  category: Scalars['String']['output'];
+};
+
+export type Menu = {
+  __typename?: 'Menu';
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  image_url?: Maybe<Scalars['String']['output']>;
+  is_a_la_carte: Scalars['Boolean']['output'];
+  service_type: MenuServiceTypeEnum;
+  is_returnable: Scalars['Boolean']['output'];
+  available: Scalars['Boolean']['output'];
+  type: Scalars['String']['output'];
+  menu_type_id: Scalars['ID']['output'];
+  public_priority: Scalars['Int']['output'];
+  menu_type?: Maybe<MenuType>;
+  price: Scalars['Float']['output'];
+  categories: Array<MenuCategory>;
+  allergens: Array<AllergenEnum>;
+  items: Array<MenuItem>;
+  created_at: Scalars['DateTime']['output'];
+  updated_at: Scalars['DateTime']['output'];
+};
+
+
+export type MenuAvailableArgs = {
+  quantity?: Scalars['Int']['input'];
+};
+
+export type MenuType = {
+  __typename?: 'MenuType';
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+  public_index: Scalars['Int']['output'];
+};
+
+export type MenuItem = {
+  __typename?: 'MenuItem';
+  id: Scalars['ID']['output'];
+  location: Location;
+  quantity: Scalars['Float']['output'];
+  unit: UnitEnum;
+  entity: MenuItemEntity;
+};
+
+export type MenuItemEntity = Ingredient | Preparation;
+
+export type MenuCategory = {
+  __typename?: 'MenuCategory';
+  /** Unique primary key. */
+  id: Scalars['ID']['output'];
+  /** Category name. */
+  name: Scalars['String']['output'];
+  /** Menus in this category. */
+  menus: Array<Menu>;
+  /** The company that owns this category. */
+  company: Company;
+  /** When the category was created. */
+  created_at: Scalars['DateTime']['output'];
+  /** When the category was last updated. */
+  updated_at: Scalars['DateTime']['output'];
+};
+
+/** Représente une commande passée dans l'établissement. */
+export type Order = {
+  __typename?: 'Order';
+  /** Identifiant unique. */
+  id: Scalars['ID']['output'];
+  /** Table associée à la commande. */
+  table: Table;
+  /** Entreprise propriétaire de la commande. */
+  company: Company;
+  /** Utilisateur qui a créé la commande. */
+  user: User;
+  /** Statut actuel de la commande. */
+  status: OrderStatusEnum;
+  /** Horodatage du passage de la commande en statut PENDING. */
+  pending_at?: Maybe<Scalars['DateTime']['output']>;
+  /** Horodatage du service de la commande. */
+  served_at?: Maybe<Scalars['DateTime']['output']>;
+  /** Horodatage du paiement de la commande. */
+  payed_at?: Maybe<Scalars['DateTime']['output']>;
+  /** Horodatage de l'annulation éventuelle. */
+  canceled_at?: Maybe<Scalars['DateTime']['output']>;
+  /** Prix total TTC calculé à partir des menus de toutes les étapes (prix × quantité). */
+  price: Scalars['Float']['output'];
+  /** Étapes associées à la commande. */
+  steps: Array<OrderStep>;
+  /** Historique des actions liées à la commande (ordre chronologique). */
+  histories: Array<OrderHistory>;
+  /** Date de création de la commande. */
+  created_at: Scalars['DateTime']['output'];
+  /** Date de dernière mise à jour. */
+  updated_at: Scalars['DateTime']['output'];
+};
+
+/** Statistiques agrégées sur les commandes. */
+export type OrdersStats = {
+  __typename?: 'OrdersStats';
+  pending: Scalars['Int']['output'];
+  served: Scalars['Int']['output'];
+  payed: Scalars['Int']['output'];
+  canceled: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
+  revenue: Scalars['Float']['output'];
+};
+
+/** Options de tri disponibles pour les commandes. */
+export type OrderOrderByClause = {
+  /** Colonne utilisée pour le tri. */
   column: OrderOrderByField;
-  /** The direction that is used for ordering. */
-  order: SortOrder;
+  /** Direction du tri. */
+  order?: SortOrder;
 };
 
-/** Order by clause for Query.orderSteps.orderBy. */
-export type QueryOrderStepsOrderByOrderByClause = {
-  /** The column that is used for ordering. */
+/** Colonnes triables pour les commandes. */
+export enum OrderOrderByField {
+  Id = 'ID',
+  Status = 'STATUS',
+  TableId = 'TABLE_ID',
+  UserId = 'USER_ID',
+  PendingAt = 'PENDING_AT',
+  ServedAt = 'SERVED_AT',
+  PayedAt = 'PAYED_AT',
+  CanceledAt = 'CANCELED_AT',
+  CreatedAt = 'CREATED_AT',
+  UpdatedAt = 'UPDATED_AT'
+}
+
+/** Historique des actions effectuées sur une commande. */
+export type OrderHistory = {
+  __typename?: 'OrderHistory';
+  /** Identifiant unique de l'entrée. */
+  id: Scalars['ID']['output'];
+  /** Commande associée à l'entrée. */
+  order: Order;
+  /** Étape concernée, le cas échéant. */
+  order_step?: Maybe<OrderStep>;
+  /** Menu d'étape concerné, le cas échéant. */
+  step_menu?: Maybe<StepMenu>;
+  /** Entreprise liée à l'entrée. */
+  company: Company;
+  /** Utilisateur ayant réalisé l'action. */
+  user?: Maybe<User>;
+  /** Type d'action enregistrée. */
+  action: OrderHistoryActionEnum;
+  /** Informations métier associées à l'action. */
+  payload?: Maybe<Scalars['JSON']['output']>;
+  /** Raison associée à l'action (si applicable). */
+  reason?: Maybe<Scalars['String']['output']>;
+  /** Date de création de l'entrée. */
+  created_at: Scalars['DateTime']['output'];
+  /** Date de dernière mise à jour. */
+  updated_at: Scalars['DateTime']['output'];
+};
+
+/** Liste des actions possibles sur l'historique des commandes. */
+export enum OrderHistoryActionEnum {
+  OrderCreated = 'ORDER_CREATED',
+  OrderStatusUpdated = 'ORDER_STATUS_UPDATED',
+  OrderStepCreated = 'ORDER_STEP_CREATED',
+  OrderStepStatusUpdated = 'ORDER_STEP_STATUS_UPDATED',
+  StepMenuAdded = 'STEP_MENU_ADDED',
+  StepMenuUpdated = 'STEP_MENU_UPDATED',
+  StepMenuRemoved = 'STEP_MENU_REMOVED',
+  StepMenuStatusUpdated = 'STEP_MENU_STATUS_UPDATED'
+}
+
+/** Étape individuelle d'une commande. */
+export type OrderStep = {
+  __typename?: 'OrderStep';
+  /** Identifiant unique. */
+  id: Scalars['ID']['output'];
+  /** Commande à laquelle appartient l'étape. */
+  order: Order;
+  /** Position de l'étape dans le flux de service. */
+  position: Scalars['Int']['output'];
+  /** Statut actuel de l'étape. */
+  status: OrderStepStatusEnum;
+  /** Horodatage du service de l'étape. */
+  served_at?: Maybe<Scalars['DateTime']['output']>;
+  /** Prix TTC de l'étape calculé en sommant prix × quantité des menus associés. */
+  price: Scalars['Float']['output'];
+  /** Menus associés à cette étape. */
+  stepMenus: Array<StepMenu>;
+  /** Menus liés via la relation pivot. */
+  menus: Array<Menu>;
+  /** Date de création de l'étape. */
+  created_at: Scalars['DateTime']['output'];
+  /** Date de dernière mise à jour. */
+  updated_at: Scalars['DateTime']['output'];
+};
+
+/** Options de tri disponibles pour les étapes de commande. */
+export type OrderStepOrderByClause = {
+  /** Colonne utilisée pour le tri. */
   column: OrderStepOrderByField;
-  /** The direction that is used for ordering. */
-  order: SortOrder;
+  /** Direction du tri. */
+  order?: SortOrder;
 };
 
-/** Order by clause for Query.rooms.orderBy. */
-export type QueryRoomsOrderByOrderByClause = {
-  /** The column that is used for ordering. */
-  column: RoomOrderByField;
-  /** The direction that is used for ordering. */
-  order: SortOrder;
+/** Colonnes triables pour les étapes de commande. */
+export enum OrderStepOrderByField {
+  Id = 'ID',
+  OrderId = 'ORDER_ID',
+  Position = 'POSITION',
+  Status = 'STATUS',
+  ServedAt = 'SERVED_AT',
+  CreatedAt = 'CREATED_AT',
+  UpdatedAt = 'UPDATED_AT'
+}
+
+export enum PerishableFilter {
+  Fresh = 'FRESH',
+  Soon = 'SOON',
+  Expired = 'EXPIRED'
+}
+
+export type Perishable = {
+  __typename?: 'Perishable';
+  id: Scalars['ID']['output'];
+  ingredient: Ingredient;
+  location: Location;
+  quantity: Scalars['Float']['output'];
+  is_read: Scalars['Boolean']['output'];
+  expiration_at: Scalars['DateTime']['output'];
+  created_at: Scalars['DateTime']['output'];
+  updated_at: Scalars['DateTime']['output'];
 };
 
-/** Order by clause for Query.stepMenus.orderBy. */
-export type QueryStepMenusOrderByOrderByClause = {
-  /** The column that is used for ordering. */
-  column: StepMenuOrderByField;
-  /** The direction that is used for ordering. */
-  order: SortOrder;
+export type Preparation = {
+  __typename?: 'Preparation';
+  /** Unique primary key. */
+  id: Scalars['ID']['output'];
+  /** Preparation name. */
+  name: Scalars['String']['output'];
+  /** Unit of measurement for the preparation. */
+  unit: UnitEnum;
+  /** Quantity for one unit of the preparation. */
+  base_quantity: Scalars['Float']['output'];
+  /** Unit for the base quantity of the preparation. */
+  base_unit: UnitEnum;
+  /** Allergens contained in this preparation. */
+  allergens: Array<AllergenEnum>;
+  /** The company that produces this preparation. */
+  company: Company;
+  /** Threshold below which the preparation is considered understocked. */
+  threshold?: Maybe<Scalars['Float']['output']>;
+  entities: Array<PreparationEntity>;
+  locations: Array<Location>;
+  /** The categories associated with this preparation. */
+  categories: Array<Category>;
+  quantities: Array<PreparationQuantity>;
+  preparable_quantity: PreparationPreparableQuantity;
+  image_url?: Maybe<Scalars['String']['output']>;
+  /** Historique des mouvements de stock pour cette préparation */
+  stockMovements: Array<StockMovement>;
+  withdrawals_today_count: Scalars['Int']['output'];
+  /** Number of withdrawals for this ingredient today. */
+  withdrawals_this_week_count: Scalars['Int']['output'];
+  /** Number of withdrawals for this ingredient this week. */
+  withdrawals_this_month_count: Scalars['Int']['output'];
+  /** When the preparation was created. */
+  created_at: Scalars['DateTime']['output'];
+  /** When the preparation was last updated. */
+  updated_at: Scalars['DateTime']['output'];
 };
 
-/** Order by clause for Query.tables.orderBy. */
-export type QueryTablesOrderByOrderByClause = {
-  /** The column that is used for ordering. */
-  column: TableOrderByField;
-  /** The direction that is used for ordering. */
-  order: SortOrder;
+export type PreparationQuantity = {
+  __typename?: 'PreparationQuantity';
+  /** Le stock de la préparation. */
+  quantity: Scalars['Float']['output'];
+  /** La localisation de ce stock. */
+  location: Location;
 };
+
+export type PreparationPreparableQuantity = {
+  __typename?: 'PreparationPreparableQuantity';
+  /** Quantité maximale préparable avec le stock actuel. */
+  quantity: Scalars['Float']['output'];
+  /** Unité associée à la préparation. */
+  unit: UnitEnum;
+};
+
+export enum PreparationOrderByField {
+  Id = 'ID',
+  Name = 'NAME',
+  CreatedAt = 'CREATED_AT',
+  UpdatedAt = 'UPDATED_AT',
+  WithdrawalsToday = 'WITHDRAWALS_TODAY',
+  WithdrawalsThisWeek = 'WITHDRAWALS_THIS_WEEK',
+  WithdrawalsThisMonth = 'WITHDRAWALS_THIS_MONTH'
+}
+
+export type PreparationOrderByClause = {
+  column: PreparationOrderByField;
+  order?: SortOrder;
+};
+
+export type PreparationEntity = {
+  __typename?: 'PreparationEntity';
+  id: Scalars['ID']['output'];
+  entity: PreparationEntityItem;
+  preparation: Preparation;
+  location: Location;
+  quantity: Scalars['Float']['output'];
+  unit: UnitEnum;
+};
+
+export type PreparationEntityItem = Ingredient | Preparation;
 
 /** Bouton d’accès rapide configurable pour une entreprise. */
 export type QuickAccess = {
@@ -1284,24 +1115,20 @@ export enum RoomOrderByField {
   UpdatedAt = 'UPDATED_AT'
 }
 
-/** A paginated list of Room items. */
-export type RoomPaginator = {
-  __typename?: 'RoomPaginator';
-  /** Pagination information about the list of items. */
-  paginatorInfo: PaginatorInfo;
-  /** A list of Room items. */
-  data: Array<Room>;
+/** Représente un produit alimentaire issu d'OpenFoodFacts */
+export type OpenFoodFactsProduct = {
+  __typename?: 'OpenFoodFactsProduct';
+  barcode?: Maybe<Scalars['String']['output']>;
+  product_name?: Maybe<Scalars['String']['output']>;
+  base_quantity?: Maybe<Scalars['Float']['output']>;
+  unit?: Maybe<Scalars['String']['output']>;
+  categories?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  imageUrl?: Maybe<Scalars['String']['output']>;
+  is_already_in_database?: Maybe<Scalars['Boolean']['output']>;
+  ingredient_id?: Maybe<Scalars['ID']['output']>;
 };
 
 export type SearchResult = Ingredient | Preparation;
-
-/** Directions for ordering a list of records. */
-export enum SortOrder {
-  /** Sort records in ascending order. */
-  Asc = 'ASC',
-  /** Sort records in descending order. */
-  Desc = 'DESC'
-}
 
 /** Association entre une étape de commande et un menu. */
 export type StepMenu = {
@@ -1344,21 +1171,6 @@ export enum StepMenuOrderByField {
   ServedAt = 'SERVED_AT',
   CreatedAt = 'CREATED_AT',
   UpdatedAt = 'UPDATED_AT'
-}
-
-/** A paginated list of StepMenu items. */
-export type StepMenuPaginator = {
-  __typename?: 'StepMenuPaginator';
-  /** Pagination information about the list of items. */
-  paginatorInfo: PaginatorInfo;
-  /** A list of StepMenu items. */
-  data: Array<StepMenu>;
-};
-
-export enum StepMenuStatusEnum {
-  InPrep = 'IN_PREP',
-  Ready = 'READY',
-  Served = 'SERVED'
 }
 
 /** Représente un mouvement de stock d'un ingrédient ou d'une préparation. */
@@ -1411,15 +1223,6 @@ export enum StockMovementOrderByField {
   UpdatedAt = 'UPDATED_AT'
 }
 
-/** A paginated list of StockMovement items. */
-export type StockMovementPaginator = {
-  __typename?: 'StockMovementPaginator';
-  /** Pagination information about the list of items. */
-  paginatorInfo: PaginatorInfo;
-  /** A list of StockMovement items. */
-  data: Array<StockMovement>;
-};
-
 export type Table = {
   __typename?: 'Table';
   /** Unique primary key. */
@@ -1441,43 +1244,6 @@ export enum TableOrderByField {
   UpdatedAt = 'UPDATED_AT'
 }
 
-/** A paginated list of Table items. */
-export type TablePaginator = {
-  __typename?: 'TablePaginator';
-  /** Pagination information about the list of items. */
-  paginatorInfo: PaginatorInfo;
-  /** A list of Table items. */
-  data: Array<Table>;
-};
-
-/** Specify if you want to include or exclude trashed results from a query. */
-export enum Trashed {
-  /** Only return trashed results. */
-  Only = 'ONLY',
-  /** Return both trashed and non-trashed results. */
-  With = 'WITH',
-  /** Only return non-trashed results. */
-  Without = 'WITHOUT'
-}
-
-export enum UnitEnum {
-  Kg = 'kg',
-  Hg = 'hg',
-  Dag = 'dag',
-  G = 'g',
-  Dg = 'dg',
-  Cg = 'cg',
-  Mg = 'mg',
-  KL = 'kL',
-  HL = 'hL',
-  DaL = 'daL',
-  L = 'L',
-  DL = 'dL',
-  CL = 'cL',
-  ML = 'mL',
-  Unit = 'unit'
-}
-
 /** Account of a person who uses this application. */
 export type User = {
   __typename?: 'User';
@@ -1497,6 +1263,162 @@ export type User = {
   updated_at: Scalars['DateTime']['output'];
 };
 
+/** Information about pagination using a fully featured paginator. */
+export type PaginatorInfo = {
+  __typename?: 'PaginatorInfo';
+  /** Number of items in the current page. */
+  count: Scalars['Int']['output'];
+  /** Index of the current page. */
+  currentPage: Scalars['Int']['output'];
+  /** Index of the first item in the current page. */
+  firstItem?: Maybe<Scalars['Int']['output']>;
+  /** Are there more pages after this one? */
+  hasMorePages: Scalars['Boolean']['output'];
+  /** Index of the last item in the current page. */
+  lastItem?: Maybe<Scalars['Int']['output']>;
+  /** Index of the last available page. */
+  lastPage: Scalars['Int']['output'];
+  /** Number of items per page. */
+  perPage: Scalars['Int']['output'];
+  /** Number of total available items. */
+  total: Scalars['Int']['output'];
+};
+
+/** A paginated list of Category items. */
+export type CategoryPaginator = {
+  __typename?: 'CategoryPaginator';
+  /** Pagination information about the list of items. */
+  paginatorInfo: PaginatorInfo;
+  /** A list of Category items. */
+  data: Array<Category>;
+};
+
+/** A paginated list of Company items. */
+export type CompanyPaginator = {
+  __typename?: 'CompanyPaginator';
+  /** Pagination information about the list of items. */
+  paginatorInfo: PaginatorInfo;
+  /** A list of Company items. */
+  data: Array<Company>;
+};
+
+/** A paginated list of Ingredient items. */
+export type IngredientPaginator = {
+  __typename?: 'IngredientPaginator';
+  /** Pagination information about the list of items. */
+  paginatorInfo: PaginatorInfo;
+  /** A list of Ingredient items. */
+  data: Array<Ingredient>;
+};
+
+/** A paginated list of Location items. */
+export type LocationPaginator = {
+  __typename?: 'LocationPaginator';
+  /** Pagination information about the list of items. */
+  paginatorInfo: PaginatorInfo;
+  /** A list of Location items. */
+  data: Array<Location>;
+};
+
+/** A paginated list of LocationType items. */
+export type LocationTypePaginator = {
+  __typename?: 'LocationTypePaginator';
+  /** Pagination information about the list of items. */
+  paginatorInfo: PaginatorInfo;
+  /** A list of LocationType items. */
+  data: Array<LocationType>;
+};
+
+/** A paginated list of Loss items. */
+export type LossPaginator = {
+  __typename?: 'LossPaginator';
+  /** Pagination information about the list of items. */
+  paginatorInfo: PaginatorInfo;
+  /** A list of Loss items. */
+  data: Array<Loss>;
+};
+
+/** A paginated list of Menu items. */
+export type MenuPaginator = {
+  __typename?: 'MenuPaginator';
+  /** Pagination information about the list of items. */
+  paginatorInfo: PaginatorInfo;
+  /** A list of Menu items. */
+  data: Array<Menu>;
+};
+
+/** A paginated list of MenuCategory items. */
+export type MenuCategoryPaginator = {
+  __typename?: 'MenuCategoryPaginator';
+  /** Pagination information about the list of items. */
+  paginatorInfo: PaginatorInfo;
+  /** A list of MenuCategory items. */
+  data: Array<MenuCategory>;
+};
+
+/** A paginated list of Order items. */
+export type OrderPaginator = {
+  __typename?: 'OrderPaginator';
+  /** Pagination information about the list of items. */
+  paginatorInfo: PaginatorInfo;
+  /** A list of Order items. */
+  data: Array<Order>;
+};
+
+/** A paginated list of OrderStep items. */
+export type OrderStepPaginator = {
+  __typename?: 'OrderStepPaginator';
+  /** Pagination information about the list of items. */
+  paginatorInfo: PaginatorInfo;
+  /** A list of OrderStep items. */
+  data: Array<OrderStep>;
+};
+
+/** A paginated list of Preparation items. */
+export type PreparationPaginator = {
+  __typename?: 'PreparationPaginator';
+  /** Pagination information about the list of items. */
+  paginatorInfo: PaginatorInfo;
+  /** A list of Preparation items. */
+  data: Array<Preparation>;
+};
+
+/** A paginated list of Room items. */
+export type RoomPaginator = {
+  __typename?: 'RoomPaginator';
+  /** Pagination information about the list of items. */
+  paginatorInfo: PaginatorInfo;
+  /** A list of Room items. */
+  data: Array<Room>;
+};
+
+/** A paginated list of StepMenu items. */
+export type StepMenuPaginator = {
+  __typename?: 'StepMenuPaginator';
+  /** Pagination information about the list of items. */
+  paginatorInfo: PaginatorInfo;
+  /** A list of StepMenu items. */
+  data: Array<StepMenu>;
+};
+
+/** A paginated list of StockMovement items. */
+export type StockMovementPaginator = {
+  __typename?: 'StockMovementPaginator';
+  /** Pagination information about the list of items. */
+  paginatorInfo: PaginatorInfo;
+  /** A list of StockMovement items. */
+  data: Array<StockMovement>;
+};
+
+/** A paginated list of Table items. */
+export type TablePaginator = {
+  __typename?: 'TablePaginator';
+  /** Pagination information about the list of items. */
+  paginatorInfo: PaginatorInfo;
+  /** A list of Table items. */
+  data: Array<Table>;
+};
+
 /** A paginated list of User items. */
 export type UserPaginator = {
   __typename?: 'UserPaginator';
@@ -1505,3 +1427,81 @@ export type UserPaginator = {
   /** A list of User items. */
   data: Array<User>;
 };
+
+/** Order by clause for Query.orders.orderBy. */
+export type QueryOrdersOrderByOrderByClause = {
+  /** The column that is used for ordering. */
+  column: OrderOrderByField;
+  /** The direction that is used for ordering. */
+  order: SortOrder;
+};
+
+/** Order by clause for Query.orderSteps.orderBy. */
+export type QueryOrderStepsOrderByOrderByClause = {
+  /** The column that is used for ordering. */
+  column: OrderStepOrderByField;
+  /** The direction that is used for ordering. */
+  order: SortOrder;
+};
+
+/** Order by clause for Query.rooms.orderBy. */
+export type QueryRoomsOrderByOrderByClause = {
+  /** The column that is used for ordering. */
+  column: RoomOrderByField;
+  /** The direction that is used for ordering. */
+  order: SortOrder;
+};
+
+/** Order by clause for Query.stepMenus.orderBy. */
+export type QueryStepMenusOrderByOrderByClause = {
+  /** The column that is used for ordering. */
+  column: StepMenuOrderByField;
+  /** The direction that is used for ordering. */
+  order: SortOrder;
+};
+
+/** Order by clause for Query.tables.orderBy. */
+export type QueryTablesOrderByOrderByClause = {
+  /** The column that is used for ordering. */
+  column: TableOrderByField;
+  /** The direction that is used for ordering. */
+  order: SortOrder;
+};
+
+/** Aggregate functions when ordering by a relation without specifying a column. */
+export enum OrderByRelationAggregateFunction {
+  /** Amount of items. */
+  Count = 'COUNT'
+}
+
+/** Aggregate functions when ordering by a relation that may specify a column. */
+export enum OrderByRelationWithColumnAggregateFunction {
+  /** Average. */
+  Avg = 'AVG',
+  /** Minimum. */
+  Min = 'MIN',
+  /** Maximum. */
+  Max = 'MAX',
+  /** Sum. */
+  Sum = 'SUM',
+  /** Amount of items. */
+  Count = 'COUNT'
+}
+
+/** Allows ordering a list of records. */
+export type OrderByClause = {
+  /** The column that is used for ordering. */
+  column: Scalars['String']['input'];
+  /** The direction that is used for ordering. */
+  order: SortOrder;
+};
+
+/** Specify if you want to include or exclude trashed results from a query. */
+export enum Trashed {
+  /** Only return trashed results. */
+  Only = 'ONLY',
+  /** Return both trashed and non-trashed results. */
+  With = 'WITH',
+  /** Only return non-trashed results. */
+  Without = 'WITHOUT'
+}


### PR DESCRIPTION
Implements offline capabilities for the PWA, including request queuing, GraphQL and ingredient data caching, and a status banner UI. Adds new modules for offline queue management, IndexedDB storage, cache utilities, and offline-aware GraphQL requests. Updates HTTP client to queue mutations when offline and replay them when back online. Integrates offline status into the UI and provides tests for offline behaviors.