### PR TITLE
[KHP-292] fix(web): Replace redirect with router.replace in order actions

### DIFF
--- a/apps/web/src/app/(mainapp)/waiters/table/[orderId]/__tests__/order-management-actions.test.tsx
+++ b/apps/web/src/app/(mainapp)/waiters/table/[orderId]/__tests__/order-management-actions.test.tsx
@@ -8,14 +8,14 @@ import { OrderStatusEnum } from '@workspace/graphql';
 
 const navigationMocks = vi.hoisted(() => ({
   refresh: vi.fn(),
-  redirect: vi.fn(),
+  replace: vi.fn(),
 }));
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({
     refresh: navigationMocks.refresh,
+    replace: navigationMocks.replace,
   }),
-  redirect: navigationMocks.redirect,
 }));
 
 describe('OrderManagementActions', () => {
@@ -31,7 +31,7 @@ describe('OrderManagementActions', () => {
 
   beforeEach(() => {
     navigationMocks.refresh.mockClear();
-    navigationMocks.redirect.mockClear();
+    navigationMocks.replace.mockClear();
   });
 
   it('disables force payment toggle when order is already served', () => {
@@ -68,7 +68,7 @@ describe('OrderManagementActions', () => {
 
     expect(payOrder).toHaveBeenCalledWith({ force: true });
     expect(navigationMocks.refresh).toHaveBeenCalled();
-    expect(navigationMocks.redirect).toHaveBeenCalledWith('/waiters');
+    expect(navigationMocks.replace).toHaveBeenCalledWith('/waiters');
   });
 
   it('shows an error message when cancel action fails', async () => {
@@ -88,6 +88,6 @@ describe('OrderManagementActions', () => {
 
     expect(cancelOrder).toHaveBeenCalled();
     expect(await screen.findByText('Unable to cancel')).toBeInTheDocument();
-    expect(navigationMocks.redirect).not.toHaveBeenCalled();
+    expect(navigationMocks.replace).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/(mainapp)/waiters/table/[orderId]/order-management-actions.tsx
+++ b/apps/web/src/app/(mainapp)/waiters/table/[orderId]/order-management-actions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { redirect, useRouter } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState, useTransition } from "react";
 import { Button } from "@workspace/ui/components/button";
 import { Card, CardContent } from "@workspace/ui/components/card";
@@ -70,7 +70,7 @@ function OrderManagementActions({
       } else {
         setForcePayment(false);
         router.refresh();
-        redirect("/waiters");
+        router.replace("/waiters");
       }
     });
   };
@@ -88,7 +88,7 @@ function OrderManagementActions({
         setError(result.error);
       } else {
         router.refresh();
-        redirect("/waiters");
+        router.replace("/waiters");
       }
     });
   };


### PR DESCRIPTION
Updated navigation logic in OrderManagementActions to use router.replace instead of redirect for navigating to /waiters after actions. This ensures navigation is handled via the Next.js router API.